### PR TITLE
fixed a ToDo auth failed case to return 0 instead of 1.

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -526,11 +526,17 @@ uint8_t Adafruit_PN532::mifareclassic_AuthenticateBlock (uint8_t * uid, uint8_t 
 
   // Read the response packet
   readspidata(pn532_packetbuffer, 12);
-  // ToDo: How to check if the response is valid and we are authenticated???
-  // #ifdef PN532DEBUG
-  //   Serial.println("Authentification failed%s");
-  // #endif
-  // return 0;
+  // check if the response is valid and we are authenticated???
+  // for an auth success it should be bytes 5-7: 0xD5 0x41 0x00
+  // Mifare auth error is technically byte 7: 0x14 but anything other and 0x00 is not good
+  if (pn532_packetbuffer[7] != 0x00)
+  {
+    #ifdef PN532DEBUG
+    Serial.print("Authentification failed: ");
+    Adafruit_PN532::PrintHexChar(pn532_packetbuffer, 12);
+    #endif
+    return 0;
+  }
 
   return 1;
 }


### PR DESCRIPTION
Auth failed was still returning 1 even in failure case, so changed it to return 0 now on fail.

Signed-off-by: Scott Gustafson scott@garlicsoftware.com
