### PR TITLE
Support for new SPI library

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -25,11 +25,19 @@
 */
 /**************************************************************************/
 
+#ifndef ADAFRUIT_PN532_H_
+#define ADAFRUIT_PN532_H_
+
 #if ARDUINO >= 100
  #include "Arduino.h"
 #else
  #include "WProgram.h"
+ #include <pins_arduino.h>
 #endif
+
+#include "pins_arduino.h"
+#include "wiring_private.h"
+#include "SPI.h"
 
 #define PN532_PREAMBLE                      (0x00)
 #define PN532_STARTCODE1                    (0x00)
@@ -140,6 +148,7 @@
 class Adafruit_PN532{
  public:
   Adafruit_PN532(uint8_t clk, uint8_t miso, uint8_t mosi, uint8_t ss);
+  Adafruit_PN532(uint8_t ss);
   void begin(void);
   
   // Generic PN532 functions
@@ -181,4 +190,7 @@ class Adafruit_PN532{
   void spiwritecommand(uint8_t* cmd, uint8_t cmdlen);
   void spiwrite(uint8_t c);
   uint8_t spiread(void);
+  boolean useHardwareSPI;
 };
+
+#endif //ADAFRUIT_PN532_H_


### PR DESCRIPTION
These changes add support for hardware SPI and SPI transactions to allow the PN532 IC to be used with other SPI peripherals