### PR TITLE
Added library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Adafruit PN532
+version=1.0
+author=Adafruit
+maintainer=Adafruit <info@adafruit.com>
+sentence=Arduino library for SPI and I2C access to the PN532 RFID/Near Field Communication chip.
+paragraph=Arduino library for SPI and I2C access to the PN532 RFID/Near Field Communication chip.
+category=Communication
+url=https://github.com/adafruit/Adafruit-PN532
+architectures=*


### PR DESCRIPTION
This PR adds library.properties, a metadata file used by the upcoming library manager to list libraries under the appropriate category and provide the user some useful additional information

See https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification for additional info on the format and the optional folder structure