### PR TITLE
The timeout function should not print to serial unless it is debugging.

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1539,7 +1539,9 @@ bool Adafruit_PN532::waitready(uint16_t timeout) {
     if (timeout != 0) {
       timer += 10;
       if (timer > timeout) {
+	#ifdef PN532DEBUG
         Serial.println("TIMEOUT!");
+	#endif
         return false;
       }
     }


### PR DESCRIPTION
I was writing a program that used Serial communication with the NFC reader and the printing of "TIMEOUT!" every time there was no tag was becoming annoying. This should only print if debugging is enabled on the NFC library.
