### PR TITLE
Added ESP8266 compatibility

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -49,7 +49,7 @@
 #endif
 
 #include <Wire.h>
-#if defined(__AVR__) || defined(__i386__) //compatibility with Intel Galileo
+#if defined(__AVR__) || defined(__i386__) || defined(ARDUINO_ARCH_ESP8266) //compatibility with Intel Galileo and ESP8266
  #define WIRE Wire
 #else // Arduino Due
  #define WIRE Wire1


### PR DESCRIPTION
Initial attempt to add support for ESP8266. Tested and found working on ESP-12E

Earlier message on having trouble combining it with NeoPixel apparently was caused by using Serial and is probably not related to the PN532 library.