### PR TITLE
serial monitor compatibility for ATmega32u4 boards

### DIFF
--- a/examples/apduToBlackBerry/apduToBlackBerry.pde
+++ b/examples/apduToBlackBerry/apduToBlackBerry.pde
@@ -63,6 +63,9 @@ void showColor() {
 }
 
 void setup() {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
 
   pinMode(R_PIN,OUTPUT);

--- a/examples/iso14443a_uid/iso14443a_uid.pde
+++ b/examples/iso14443a_uid/iso14443a_uid.pde
@@ -55,6 +55,9 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Hello!");
 

--- a/examples/mifareclassic_formatndef/mifareclassic_formatndef.pde
+++ b/examples/mifareclassic_formatndef/mifareclassic_formatndef.pde
@@ -75,6 +75,9 @@ uint8_t ndefprefix = NDEF_URIPREFIX_HTTP_WWWDOT;
 
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Looking for PN532...");
 

--- a/examples/mifareclassic_memdump/mifareclassic_memdump.pde
+++ b/examples/mifareclassic_memdump/mifareclassic_memdump.pde
@@ -54,6 +54,9 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   // has to be fast to dump the entire memory contents!
   Serial.begin(115200);
   Serial.println("Looking for PN532...");

--- a/examples/mifareclassic_ndeftoclassic/mifareclassic_ndeftoclassic.pde
+++ b/examples/mifareclassic_ndeftoclassic/mifareclassic_ndeftoclassic.pde
@@ -71,6 +71,9 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 static const uint8_t KEY_DEFAULT_KEYAB[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Looking for PN532...");
 

--- a/examples/mifareclassic_updatendef/mifareclassic_updatendef.pde
+++ b/examples/mifareclassic_updatendef/mifareclassic_updatendef.pde
@@ -71,6 +71,9 @@ uint8_t ndefprefix = NDEF_URIPREFIX_HTTP_WWWDOT;
 
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Looking for PN532...");
 

--- a/examples/ntag2xx_erase/ntag2xx_erase.pde
+++ b/examples/ntag2xx_erase/ntag2xx_erase.pde
@@ -51,6 +51,9 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Hello!");
 

--- a/examples/ntag2xx_read/ntag2xx_read.pde
+++ b/examples/ntag2xx_read/ntag2xx_read.pde
@@ -50,6 +50,9 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Hello!");
 

--- a/examples/ntag2xx_updatendef/ntag2xx_updatendef.pde
+++ b/examples/ntag2xx_updatendef/ntag2xx_updatendef.pde
@@ -69,6 +69,9 @@ uint8_t ndefprefix = NDEF_URIPREFIX_HTTP_WWWDOT;
 //uint8_t ndefprefix = NDEF_URIPREFIX_TEL;
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Hello!");
 

--- a/examples/readMifare/readMifare.pde
+++ b/examples/readMifare/readMifare.pde
@@ -65,6 +65,9 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Hello!");
 

--- a/examples/readMifareClassic/readMifareClassic.pde
+++ b/examples/readMifareClassic/readMifareClassic.pde
@@ -62,6 +62,9 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
 void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
   Serial.begin(115200);
   Serial.println("Hello!");
 


### PR DESCRIPTION
code added for serial monitor to work with ATmega32u4 boards