### PR TITLE
Allow compilation on Teensy 3.x and LC chips.

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -49,7 +49,7 @@
 #endif
 
 #include <Wire.h>
-#if defined(__AVR__) || defined(__i386__) || defined(ARDUINO_ARCH_SAMD) || defined(ESP8266) //compatibility with Intel Galileo
+#if defined(__AVR__) || defined(CORE_TEENSY) || defined(__i386__) || defined(ARDUINO_ARCH_SAMD) || defined(ESP8266) //compatibility with Intel Galileo
  #define WIRE Wire
 #else // Arduino Due
  #define WIRE Wire1


### PR DESCRIPTION
Current code assumes any unrecognized system is Arduino Due, and defines WIRE as Wire1, which won't compile on Teensy LC or 3.x. This change checks for CORE_TEENSY being defined, and if so, understands that we aren't on a Arduino Due, and that WIRE should be defined as Wire.
