### PR TITLE
Generate data checksum cleanly

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1638,6 +1638,7 @@ void Adafruit_PN532::writecommand(uint8_t* cmd, uint8_t cmdlen) {
   if (_usingSPI) {
     // SPI command write.
     uint8_t checksum;
+    checksum = 0xFF;
 
     cmdlen++;
 
@@ -1652,7 +1653,6 @@ void Adafruit_PN532::writecommand(uint8_t* cmd, uint8_t cmdlen) {
     delay(2);     // or whatever the delay is for waking up the board
     spi_write(PN532_SPI_DATAWRITE);
 
-    checksum = PN532_PREAMBLE + PN532_PREAMBLE + PN532_STARTCODE2;
     spi_write(PN532_PREAMBLE);
     spi_write(PN532_PREAMBLE);
     spi_write(PN532_STARTCODE2);
@@ -1707,7 +1707,6 @@ void Adafruit_PN532::writecommand(uint8_t* cmd, uint8_t cmdlen) {
 
     // I2C START
     WIRE.beginTransmission(PN532_I2C_ADDRESS);
-    checksum = PN532_PREAMBLE + PN532_PREAMBLE + PN532_STARTCODE2;
     i2c_send(PN532_PREAMBLE);
     i2c_send(PN532_PREAMBLE);
     i2c_send(PN532_STARTCODE2);


### PR DESCRIPTION
Hi,

This pull request:
- affects the data checksum generation for sending commands to the PN532.
- has no limitations known to me.
- should work with the provided examples.

In the PN532 User Manual (http://www.nxp.com/documents/user_manual/141520.pdf), section 6.2.1, the data checksum (DCS) is defined as:

`TFI + PD0 + PD1 + ... + PDn + DCS = 0x00.`

The removed lines conveniently had no net affect on the checksum outcome due to the values represented by preamble and startcode (0x00 and 0xFF). Removing it simply improves readability to those following along with the code.

Thanks,
Christopher Bero