### PR TITLE
Fixes print statement typo in ntag2xx example.

### DIFF
--- a/examples/ntag2xx_erase/ntag2xx_erase.pde
+++ b/examples/ntag2xx_erase/ntag2xx_erase.pde
@@ -119,7 +119,7 @@ void loop(void) {
       // NTAG 216       231     4             225      
 
       Serial.println("");
-      Serial.println("Writing 0x00 0x00 0x00 0x00 to pages 4..29");
+      Serial.println("Writing 0x00 0x00 0x00 0x00 to pages 4..39");
       Serial.println("");
       for (uint8_t i = 4; i < 39; i++) 
       {


### PR DESCRIPTION
# Why?

Fixes a typo in ntag2xx_erase.pde example code.
