### PR TITLE
Print TIMEOUT! only if defined PN532DEBUG

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1547,7 +1547,9 @@ bool Adafruit_PN532::waitready(uint16_t timeout) {
     if (timeout != 0) {
       timer += 10;
       if (timer > timeout) {
-        PN532DEBUGPRINT.println("TIMEOUT!");
+	#ifdef PN532DEBUG
+          PN532DEBUGPRINT.println("TIMEOUT!");
+	#endif
         return false;
       }
     }


### PR DESCRIPTION
TIMEOUT! was printed always to serial port.
Fixed it by surrounding PN532DEBUGPRINT.println("TIMEOUT!");
with #ifdef PN532DEBUG
