### PR TITLE
Added support for extended frames, fixes #38

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -79,7 +79,7 @@ byte pn532response_firmwarevers[] = {0x00, 0xFF, 0x06, 0xFA, 0xD5, 0x03};
     #define PN532_SPI_CLOCKDIV SPI_CLOCK_DIV16
 #endif
 
-#define PN532_PACKBUFFSIZ 280
+#define PN532_PACKBUFFSIZ 64
 byte pn532_packetbuffer[PN532_PACKBUFFSIZ];
 
 #ifndef _BV

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -40,6 +40,7 @@
 #define PN532_STARTCODE1                    (0x00)
 #define PN532_STARTCODE2                    (0xFF)
 #define PN532_POSTAMBLE                     (0x00)
+#define PN532_EXTENDED_FRAME_FIXED_VALUE    (0xFF)
 
 #define PN532_HOSTTOPN532                   (0xD4)
 #define PN532_PN532TOHOST                   (0xD5)
@@ -170,7 +171,7 @@ class Adafruit_PN532{
   
   // ISO14443A functions
   bool readPassiveTargetID(uint8_t cardbaudrate, uint8_t * uid, uint8_t * uidLength, uint16_t timeout = 0); //timeout 0 means no timeout - will block forever.
-  bool inDataExchange(uint8_t * send, uint8_t sendLength, uint8_t * response, uint8_t * responseLength);
+  bool inDataExchange(uint8_t * send, uint8_t sendLength, uint8_t * response, uint16_t * responseLength);
   bool inListPassiveTarget();
   
   // Mifare Classic functions
@@ -206,7 +207,7 @@ class Adafruit_PN532{
   bool    _hardwareSPI;  // True is using hardware SPI, false if using software SPI.
 
   // Low level communication functions that handle both SPI and I2C.
-  void readdata(uint8_t* buff, uint8_t n);
+  void readdata(uint8_t* buff, uint16_t n);
   void writecommand(uint8_t* cmd, uint8_t cmdlen);
   bool isready();
   bool waitready(uint16_t timeout);


### PR DESCRIPTION
Adds support for extended frames, as described on page of PN532C106 Application Note.
https://cdn-shop.adafruit.com/datasheets/PN532C106_Application+Note_v1.2.pdf#page=10

I changed the _length_ variable mentioned in issue #38 to be a uint16_t, along with the _n_ and _responseLength_ parameters of [readdata](https://github.com/BrightSoul/Adafruit-PN532/blob/08eb36b832f1e69b132e9af6eadefd92c8ff5e04/Adafruit_PN532.cpp#L1584) and [inDataExchange](https://github.com/BrightSoul/Adafruit-PN532/blob/08eb36b832f1e69b132e9af6eadefd92c8ff5e04/Adafruit_PN532.cpp#L648) methods to allow a bigger response to be read.

In order to actually be able to read large responses, the [PN532_BUFFSIZ define](https://github.com/adafruit/Adafruit-PN532/blob/master/Adafruit_PN532.cpp#L80) must be changed to a bigger value by the user (I tested with a value of 280). It would be nice if this value could be set from the outside, with a public method but this is out of the scope of this pull request. 

Also, implemented the length and length checksum calculations.
https://github.com/BrightSoul/Adafruit-PN532/blob/08eb36b832f1e69b132e9af6eadefd92c8ff5e04/Adafruit_PN532.cpp#L686

Tests were performed using my application library:
https://github.com/BrightSoul/cie-PN532
