### PR TITLE
Add ISO14443B support

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -95,6 +95,7 @@
 #define PN532_I2C_READYTIMEOUT              (20)
 
 #define PN532_MIFARE_ISO14443A              (0x00)
+#define PN532_ISO14443B                     (0x03)
 
 // Mifare Commands
 #define MIFARE_CMD_AUTH_A                   (0x60)
@@ -168,10 +169,11 @@ class Adafruit_PN532{
   uint8_t  readGPIO(void);
   bool     setPassiveActivationRetries(uint8_t maxRetries);
   
-  // ISO14443A functions
+  // ISO14443 functions
   bool readPassiveTargetID(uint8_t cardbaudrate, uint8_t * uid, uint8_t * uidLength, uint16_t timeout = 0); //timeout 0 means no timeout - will block forever.
   bool inDataExchange(uint8_t * send, uint8_t sendLength, uint8_t * response, uint8_t * responseLength);
   bool inListPassiveTarget();
+  bool inListPassiveTarget(uint8_t cardBaudRate);
   
   // Mifare Classic functions
   bool    mifareclassic_IsFirstBlock (uint32_t uiBlock);


### PR DESCRIPTION
These changes allows users to detect, inList and exchange data with ISO14443B cards.

This commit has only been tested with ISO14443B cards (e.g. Singapore CEPAS standard cards) and SPI with an ESP8266 -- more testing may be required to ensure it doesn't break anything with other cards or protocols.

(As a unrelated sidenote, in case you're planning to test this with a CEPAS card: on certain modules, the antennas may not be able to read CEPAS standard cards. I've had success with a larger module with a rectangular (not square) antenna though. YMMV.)