### PR TITLE
Fix strncmp checking

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1499,7 +1499,7 @@ bool Adafruit_PN532::readack() {
 
   readdata(ackbuff, 6);
 
-  return (0 == strncmp((char *)ackbuff, (char *)pn532ack, 6));
+  return (0 == memcmp((char *)ackbuff, (char *)pn532ack, 6));
 }
 
 

--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -307,19 +307,20 @@ uint32_t Adafruit_PN532::getFirmwareVersion(void) {
   if (! sendCommandCheckAck(pn532_packetbuffer, 1)) {
     return 0;
   }
-
+  
   // read data packet
   readdata(pn532_packetbuffer, 12);
+  int offset = _usingSPI ? 0 : 1; // Skip a response byte when using I2C to ignore extra data.
 
   // check some basic stuff
-  if (0 != strncmp((char *)pn532_packetbuffer, (char *)pn532response_firmwarevers, 6)) {
+  if (0 != memcmp((char *) &pn532_packetbuffer[offset], (char *)pn532response_firmwarevers, 6)) {
 #ifdef PN532DEBUG
       PN532DEBUGPRINT.println(F("Firmware doesn't match!"));
 #endif
     return 0;
   }
 
-  int offset = _usingSPI ? 6 : 7;  // Skip a response byte when using I2C to ignore extra data.
+  offset = _usingSPI ? 6 : 7;  // Skip a response byte when using I2C to ignore extra data.
   response = pn532_packetbuffer[offset++];
   response <<= 8;
   response |= pn532_packetbuffer[offset++];


### PR DESCRIPTION
Changes strncmp to memcmp because the first byte in pn532response_firmwarevers is 0x00, which causes strncmp to prematurely return as a match as long as both it and pn532_packetbuffer start with 0x00.

In the original code when using I2C, a 1-byte offset causes a mismatch between pn532response_firmwarevers and pn532_packetbuffer, but strncmp fails to catch this and continues to proceed.

readack() has also been updated for a similar reason.

- Scope: Firmware version checking, Ack reading

- Known limitations: None

- Tests: Run firmware version checking (like in readMifare) in both I2C and SPI modes
