### PR TITLE
ntag2xx_WriteNDEFURI NTAG215 and NTAG216 compatability

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1441,7 +1441,7 @@ uint8_t Adafruit_PN532::ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url,
     return 0;
 
   // Write URI (starting at page 7)
-  uint16_t currentPage = 7;
+  uint8_t currentPage = 7;
   char * urlcopy = url;
   while(len)
   {

--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1395,7 +1395,7 @@ uint8_t Adafruit_PN532::ntag2xx_WritePage (uint8_t page, uint8_t * data)
     @returns 1 if everything executed properly, 0 for an error
 */
 /**************************************************************************/
-uint8_t Adafruit_PN532::ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url, uint8_t dataLen)
+uint8_t Adafruit_PN532::ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url, uint16_t dataLen)
 {
   uint8_t pageBuffer[4] = { 0, 0, 0, 0 };
 
@@ -1403,7 +1403,7 @@ uint8_t Adafruit_PN532::ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url,
   uint8_t wrapperSize = 12;
 
   // Figure out how long the string is
-  uint8_t len = strlen(url);
+  uint16_t len = strlen(url);
 
   // Make sure the URI payload will fit in dataLen (include 0xFE trailer)
   if ((len < 1) || (len+1 > (dataLen-wrapperSize)))
@@ -1441,7 +1441,7 @@ uint8_t Adafruit_PN532::ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url,
     return 0;
 
   // Write URI (starting at page 7)
-  uint8_t currentPage = 7;
+  uint16_t currentPage = 7;
   char * urlcopy = url;
   while(len)
   {
@@ -1547,7 +1547,9 @@ bool Adafruit_PN532::waitready(uint16_t timeout) {
     if (timeout != 0) {
       timer += 10;
       if (timer > timeout) {
-        PN532DEBUGPRINT.println("TIMEOUT!");
+        #ifdef PN532DEBUG
+          PN532DEBUGPRINT.println("TIMEOUT!");
+        #endif
         return false;
       }
     }

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -189,7 +189,7 @@ class Adafruit_PN532{
   // NTAG2xx functions
   uint8_t ntag2xx_ReadPage (uint8_t page, uint8_t * buffer);
   uint8_t ntag2xx_WritePage (uint8_t page, uint8_t * data);
-  uint8_t ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url, uint8_t dataLen);
+  uint8_t ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url, uint16_t dataLen);
   
   // Help functions to display formatted text
   static void PrintHex(const byte * data, const uint32_t numBytes);


### PR DESCRIPTION
Changed the dataLen frim uint8_t to uint16_t to accommodate the larger data capacity,
Also made the "TIMEOUT!" message only print when debugging is turned on.

Tested on an Arduino micro writing 483 characters to a NTAG215 tag.  