### PR TITLE
Adding PN532 ISO14443A Emulation Support 

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -172,6 +172,9 @@ class Adafruit_PN532{
   bool readPassiveTargetID(uint8_t cardbaudrate, uint8_t * uid, uint8_t * uidLength, uint16_t timeout = 0); //timeout 0 means no timeout - will block forever.
   bool inDataExchange(uint8_t * send, uint8_t sendLength, uint8_t * response, uint8_t * responseLength);
   bool inListPassiveTarget();
+  uint8_t AsTarget();
+  uint8_t getDataTarget(uint8_t* cmd, uint8_t* cmdlen);
+  uint8_t setDataTarget(uint8_t * cmd, uint8_t cmdlen);
   
   // Mifare Classic functions
   bool    mifareclassic_IsFirstBlock (uint32_t uiBlock);

--- a/examples/iso14443as_target/iso14443as_target.pde
+++ b/examples/iso14443as_target/iso14443as_target.pde
@@ -1,0 +1,117 @@
+/**************************************************************************/
+/*! 
+    @file     iso14443as_target.pde
+    @original Adafruit Industries
+    @modified Salvador Mendoza(@Netxing)
+    @license  BSD (see license.txt)
+
+    This example will attempt to mimic an ISO14443A smart card
+    and retrieve some basic information from a PoS or terminal,
+    this can be used to establish a communication process.   
+   
+    Note that you need the baud rate to be 115200 because we need to print
+    out the data and read from the card at the same time!
+
+This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
+This library works with the Adafruit NFC breakout 
+  ----> https://www.adafruit.com/products/364
+ 
+Check out the links above for our tutorials and wiring diagrams 
+These chips use SPI or I2C to communicate.
+
+Adafruit invests time and resources providing this open source code, 
+please support Adafruit and open-source hardware by purchasing 
+products from Adafruit!
+
+*/
+/**************************************************************************/
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_PN532.h>
+
+// If using the breakout with SPI, define the pins for SPI communication.
+#define PN532_SCK  (2)
+#define PN532_MOSI (3)
+#define PN532_SS   (4)
+#define PN532_MISO (5)
+
+// If using the breakout or shield with I2C, define just the pins connected
+// to the IRQ and reset lines.  Use the values below (2, 3) for the shield!
+#define PN532_IRQ   (2)
+#define PN532_RESET (3)  // Not connected by default on the NFC Shield
+
+// Uncomment just _one_ line below depending on how your breakout or shield
+// is connected to the Arduino:
+
+// Use this line for a breakout with a SPI connection:
+Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
+
+// Use this line for a breakout with a hardware SPI connection.  Note that
+// the PN532 SCK, MOSI, and MISO pins need to be connected to the Arduino's
+// hardware SPI SCK, MOSI, and MISO pins.  On an Arduino Uno these are
+// SCK = 13, MOSI = 11, MISO = 12.  The SS line can be any digital IO pin.
+//Adafruit_PN532 nfc(PN532_SS);
+
+// Or use this line for a breakout or shield with an I2C connection:
+//Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
+
+#if defined(ARDUINO_ARCH_SAMD)
+// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
+// also change #define in Adafruit_PN532.cpp library file
+   #define Serial SerialUSB
+#endif
+
+void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
+  Serial.begin(115200);
+  Serial.println("Hello!");
+
+  nfc.begin();
+
+  uint32_t versiondata = nfc.getFirmwareVersion();
+  if (! versiondata) {
+    Serial.print("Didn't find PN53x board");
+    while (1); // halt
+  }
+  
+  // Got ok data, print it out!
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
+  
+  // Set the max number of retry attempts to read from a card
+  // This prevents us from waiting forever for a card, which is
+  // the default behaviour of the PN532.
+  nfc.setPassiveActivationRetries(0xFF);
+  
+  // configure board to read RFID tags
+  nfc.SAMConfig();
+  
+  Serial.println("As Target... Approach the NFC PN532 Board to a PoS or terminal!");
+  delay(200);
+}
+
+void loop(void) {
+  boolean success;
+  uint8_t apdubuffer[255] = {}, apdulen;
+  uint8_t ppse[] = {0x8E, 0x6F, 0x23, 0x84, 0x0E, 0x32, 0x50, 0x41, 0x59, 0x2E, 0x53, 0x59, 0x53, 0x2E, 0x44, 0x44, 0x46, 0x30, 0x31, 0xA5, 0x11, 0xBF, 0x0C, 0x0E, 0x61, 0x0C, 0x4F, 0x07, 0xA0, 0x00, 0x00, 0x00, 0x03, 0x10, 0x10, 0x87, 0x01, 0x01, 0x90, 0x00};
+  nfc.AsTarget();
+  success = nfc.getDataTarget(apdubuffer, &apdulen); //Read initial APDU
+  if (apdulen>0){
+    for (uint8_t i = 0; i < apdulen; i++){
+      Serial.print(" 0x"); Serial.print(apdubuffer[i], HEX);
+    }
+    Serial.println("");
+  }
+  nfc.setDataTarget(ppse, sizeof(ppse));   //Mimic a smart card response with a PPSE APDU
+  nfc.getDataTarget(apdubuffer, &apdulen); //Read respond from the PoS or Terminal
+  if (apdulen>0){
+    for (uint8_t i = 0; i < apdulen; i++){
+      Serial.print(" 0x"); Serial.print(apdubuffer[i], HEX);
+    }
+    Serial.println("");
+  }
+  delay(1000);
+}


### PR DESCRIPTION
These changes will add PN532 emulation support; the PN532 will be able
to act as smart card. I tested in different Arduino versions: Nano, Uno & clones.
Also I tested it in an ESP32 and LoRa boards. So we are going to have fun.

There is no limitation with these changes. 