### PR TITLE
changed strncmp to memcmp as intended.

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -314,7 +314,7 @@ uint32_t Adafruit_PN532::getFirmwareVersion(void) {
   readdata(pn532_packetbuffer, 12);
 
   // check some basic stuff
-  if (0 != strncmp((char *)pn532_packetbuffer, (char *)pn532response_firmwarevers, 6)) {
+  if (0 != memcmp((char *)pn532_packetbuffer, (char *)pn532response_firmwarevers, 6)) {
 #ifdef PN532DEBUG
       PN532DEBUGPRINT.println(F("Firmware doesn't match!"));
 #endif
@@ -1500,7 +1500,7 @@ bool Adafruit_PN532::readack() {
 
   readdata(ackbuff, 6);
 
-  return (0 == strncmp((char *)ackbuff, (char *)pn532ack, 6));
+  return (0 == memcmp((char *)ackbuff, (char *)pn532ack, 6));
 }
 
 


### PR DESCRIPTION
I am reading your code and ran into this. You're using strncmp where this is not appropriate. 

strncmp will stop comparing when there is a 0 in either string OR if it runs into the end after comparing n bytes. 

So in the below code, strncmp will return "0": strings are the same (both empty: "")  while they should be considered different. 

```
#include <string.h>
#include <stdio.h>
#include <stdlib.h>

unsigned char pn532ack[] = {0x00, 0x00, 0xFF, 0x00, 0xFF, 0x00};
unsigned char pn532ack2[] = {0x00, 0x00, 0xFE, 0x00, 0xFF, 0x00};

int main (int argc, char **argv)
{
   printf ("strcmp = %d, memcmp = %d.\n", 
        strncmp ((char *)pn532ack,(char *)pn532ack2,6),
        memcmp  ((char *)pn532ack,(char *)pn532ack2,6)); 
  exit (0);
}
```

Note that I haven't tested this on arduino: I have verified my understanding of the strncmp and memcmp functions with the above test-program on Linux. 

