### PR TITLE
Better support for using the IRQ line in I2C

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -20,7 +20,7 @@
     @section  HISTORY
 
     v2.2 - Added startPassiveTargetIDDetection() to start card detection and
-            readDetectedPassiveTargetID() to read it, useful when using the 
+            readDetectedPassiveTargetID() to read it, useful when using the
             IRQ pin.
 
     v2.1 - Added NTAG2xx helper functions
@@ -550,7 +550,7 @@ bool Adafruit_PN532::readPassiveTargetID(uint8_t cardbaudrate, uint8_t *uid,
 /**************************************************************************/
 bool Adafruit_PN532::startPassiveTargetIDDetection(uint8_t cardbaudrate) {
   pn532_packetbuffer[0] = PN532_COMMAND_INLISTPASSIVETARGET;
-  pn532_packetbuffer[1] = 1;  // max 1 cards at once (we can set this to 2 later)
+  pn532_packetbuffer[1] = 1; // max 1 cards at once (we can set this to 2 later)
   pn532_packetbuffer[2] = cardbaudrate;
 
   return sendCommandCheckAck(pn532_packetbuffer, 3);
@@ -568,7 +568,8 @@ bool Adafruit_PN532::startPassiveTargetIDDetection(uint8_t cardbaudrate) {
     @returns 1 if everything executed properly, 0 for an error
 */
 /**************************************************************************/
-bool Adafruit_PN532::readDetectedPassiveTargetID(uint8_t * uid, uint8_t * uidLength) {
+bool Adafruit_PN532::readDetectedPassiveTargetID(uint8_t *uid,
+                                                 uint8_t *uidLength) {
   // read data packet
   readdata(pn532_packetbuffer, 20);
   // check some basic stuff

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -171,6 +171,8 @@ public:
   bool readPassiveTargetID(
       uint8_t cardbaudrate, uint8_t *uid, uint8_t *uidLength,
       uint16_t timeout = 0); // timeout 0 means no timeout - will block forever.
+  bool startPassiveTargetIDDetection(uint8_t cardbaudrate);
+  bool readDetectedPassiveTargetID(uint8_t * uid, uint8_t * uidLength);
   bool inDataExchange(uint8_t *send, uint8_t sendLength, uint8_t *response,
                       uint8_t *responseLength);
   bool inListPassiveTarget();

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -172,7 +172,7 @@ public:
       uint8_t cardbaudrate, uint8_t *uid, uint8_t *uidLength,
       uint16_t timeout = 0); // timeout 0 means no timeout - will block forever.
   bool startPassiveTargetIDDetection(uint8_t cardbaudrate);
-  bool readDetectedPassiveTargetID(uint8_t * uid, uint8_t * uidLength);
+  bool readDetectedPassiveTargetID(uint8_t *uid, uint8_t *uidLength);
   bool inDataExchange(uint8_t *send, uint8_t sendLength, uint8_t *response,
                       uint8_t *responseLength);
   bool inListPassiveTarget();

--- a/examples/readMifareClassicIrq/readMifareClassicIrq.ino
+++ b/examples/readMifareClassicIrq/readMifareClassicIrq.ino
@@ -1,0 +1,154 @@
+/**************************************************************************/
+/*! 
+    @file     readMifareClassicIrq.pde
+    @author   Adafruit Industries
+	@license  BSD (see license.txt)
+
+    This example will wait for any ISO14443A card or tag, and
+    depending on the size of the UID will attempt to read from it.
+   
+    If the card has a 4-byte UID it is probably a Mifare
+    Classic card, and the following steps are taken:
+   
+    Reads the 4 byte (32 bit) ID of a MiFare Classic card.
+    Since the classic cards have only 32 bit identifiers you can stick
+	them in a single variable and use that to compare card ID's as a
+	number. This doesn't work for ultralight cards that have longer 7
+	byte IDs!
+    
+    Note that you need the baud rate to be 115200 because we need to
+	print out the data and read from the card at the same time!
+
+This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
+This library works with the Adafruit NFC breakout 
+  ----> https://www.adafruit.com/products/364
+ 
+Check out the links above for our tutorials and wiring diagrams 
+
+This example is for communicating with the PN532 chip using I2C. Wiring 
+should be as follows:
+  PN532 SDA -> SDA pin
+  PN532 SCL -> SCL pin
+  PN532 IRQ -> D2
+  PN532 SDA -> 3.3v (with 2k resistor)
+  PN532 SCL -> 3.3v (with 2k resistor)
+  PN532 3.3v -> 3.3v
+  PN532 GND -> GND
+
+Adafruit invests time and resources providing this open source code, 
+please support Adafruit and open-source hardware by purchasing 
+products from Adafruit!
+*/
+/**************************************************************************/
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_PN532.h>
+
+// If using the breakout with SPI, define the pins for SPI communication.
+#define PN532_SCK  (2)
+#define PN532_MOSI (3)
+#define PN532_SS   (4)
+#define PN532_MISO (5)
+
+// If using the breakout or shield with I2C, define just the pins connected
+// to the IRQ and reset lines.  Use the values below (2, 3) for the shield!
+#define PN532_IRQ   (2)
+#define PN532_RESET (3)  // Not connected by default on the NFC Shield
+
+const int DELAY_BETWEEN_CARDS = 500;
+long timeLastCardRead = 0;
+boolean readerDisabled = false;
+int irqCurr;
+int irqPrev;
+
+// This example uses the IRQ line, which is available when in I2C mode.
+Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial) delay(10); // for Leonardo/Micro/Zero
+
+  Serial.println("Hello!");
+
+  nfc.begin();
+
+  uint32_t versiondata = nfc.getFirmwareVersion();
+  if (! versiondata) {
+    Serial.print("Didn't find PN53x board");
+    while (1); // halt
+  }
+  // Got ok data, print it out!
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
+  
+  // configure board to read RFID tags
+  nfc.SAMConfig();
+
+  startListeningToNFC();
+}
+
+void loop(void) {
+  if (readerDisabled) {
+    if (millis() - timeLastCardRead > DELAY_BETWEEN_CARDS) {
+      readerDisabled = false;
+      startListeningToNFC();
+    }
+  } else {
+    irqCurr = digitalRead(PN532_IRQ);
+
+    // When the IRQ is pulled low - the reader has got something for us.
+    if (irqCurr == LOW && irqPrev == HIGH) {
+       Serial.println("Got NFC IRQ");  
+       handleCardDetected(); 
+    }
+  
+    irqPrev = irqCurr;
+  }
+}
+
+void startListeningToNFC() {
+  // Reset our IRQ indicators
+  irqPrev = irqCurr = HIGH;
+  
+  Serial.println("Waiting for an ISO14443A Card ...");
+  nfc.startPassiveTargetIDDetection(PN532_MIFARE_ISO14443A);
+}
+
+void handleCardDetected() {
+    uint8_t success = false;
+    uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
+    uint8_t uidLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
+
+    // read the NFC tag's info
+    success = nfc.readDetectedPassiveTargetID(uid, &uidLength);
+    Serial.println(success ? "Read successful" : "Read failed (not a card?)");
+
+    if (success) {
+      // Display some basic information about the card
+      Serial.println("Found an ISO14443A card");
+      Serial.print("  UID Length: ");Serial.print(uidLength, DEC);Serial.println(" bytes");
+      Serial.print("  UID Value: ");
+      nfc.PrintHex(uid, uidLength);
+      
+      if (uidLength == 4)
+      {
+        // We probably have a Mifare Classic card ... 
+        uint32_t cardid = uid[0];
+        cardid <<= 8;
+        cardid |= uid[1];
+        cardid <<= 8;
+        cardid |= uid[2];  
+        cardid <<= 8;
+        cardid |= uid[3]; 
+        Serial.print("Seems to be a Mifare Classic card #");
+        Serial.println(cardid);
+      }
+      Serial.println("");
+
+      timeLastCardRead = millis();
+    }
+
+    // The reader will be enabled again after DELAY_BETWEEN_CARDS ms will pass.
+    readerDisabled = true;
+}


### PR DESCRIPTION
Using the IRQ line we can save the host controller from being blocked waiting for new cards. When a new card is detected, the PN532 will drive the IRQ to be low (It's usually high, see [the PN532 user manual](https://www.nxp.com/docs/en/user-guide/141520.pdf)), which will let the host controller know it can try to read the detected card. This frees the host controller to do other things while waiting for new cards to be detected.

To implement this, I added a method for starting the card detection mode (startPassiveTargetIDDetection()) and another method for reading the detected card (readDetectedPassiveTargetID()). We need the PN532 to be connected using I2C and have the IRQ line connected to one of the pins in the host controller. The flow is like this:
1. Host controller calls startPassiveTargetIDDetection()
2. Assuming the IRQ is connected to pin D2, when this pin is low then we know there's a card detected by the reader.
3. The host controller calls readDetectedPassiveTargetID() to read the card information.
4. Host controller can call startPassiveTargetIDDetection() again to start listening again for new cards.

I added readMifareClassicIrq.ino as a working example for this method. There's more documentation in the example, including a wiring diagram.

This code was tested with both Arduino Mega2560 and ESP32. The changes I made are adding a new functionality and aren't affecting any existing functionality. Everything is backward compatible. The new feature is only relevant in I2C mode, SPI or UART modes aren't affected.

I added this code because there's no clear example how to use the IRQ line, not in the [official tutorial](https://learn.adafruit.com/adafruit-pn532-rfid-nfc/breakout-wiring) nor in any of the relevant discussion forums. I hope this helps others like me who struggled trying to get this behavior to work.