### PR TITLE
Added options to manage custom I2C declaration

### DIFF
--- a/Adafruit-PN532.h
+++ b/Adafruit-PN532.h
@@ -1,0 +1,2 @@
+#include "Adafruit_PN532.h"
+

--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -94,7 +94,7 @@ byte pn532_packetbuffer[PN532_PACKBUFFSIZ]; ///< Packet buffer used in various
     @param  x    The byte to send
 */
 /**************************************************************************/
-static inline void i2c_send(TwoWire & wire, uint8_t x) {
+static inline void i2c_send(TwoWire &wire, uint8_t x) {
 #if ARDUINO >= 100
   wire.write((uint8_t)x);
 #else
@@ -107,7 +107,7 @@ static inline void i2c_send(TwoWire & wire, uint8_t x) {
     @brief  Reads a single byte via I2C
 */
 /**************************************************************************/
-static inline uint8_t i2c_recv(TwoWire & wire) {
+static inline uint8_t i2c_recv(TwoWire &wire) {
 #if ARDUINO >= 100
   return wire.read();
 #else

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -15,6 +15,7 @@
 
 #include "Arduino.h"
 #include <Adafruit_SPIDevice.h>
+#include <Wire.h>
 
 #define PN532_PREAMBLE (0x00)   ///< Command sequence start, byte 1/3
 #define PN532_STARTCODE1 (0x00) ///< Command sequence start, byte 2/3
@@ -139,9 +140,15 @@
 class Adafruit_PN532 {
 public:
   Adafruit_PN532(uint8_t clk, uint8_t miso, uint8_t mosi,
-                 uint8_t ss);                 // Software SPI
-  Adafruit_PN532(uint8_t irq, uint8_t reset); // Hardware I2C
-  Adafruit_PN532(uint8_t ss);                 // Hardware SPI
+                 uint8_t ss); // Software SPI
+  Adafruit_PN532(uint8_t irq, uint8_t reset,
+#ifdef __SAM3X8E__
+                 TwoWire *wire = &Wire1
+#else
+                 TwoWire *wire = &Wire
+#endif
+                );
+  Adafruit_PN532(uint8_t ss); // Hardware SPI
   void begin(void);
 
   // Generic PN532 functions
@@ -198,6 +205,7 @@ private:
   int8_t _uidLen;      // uid len
   int8_t _key[6];      // Mifare Classic key
   int8_t _inListedTag; // Tg number of inlisted tag.
+  TwoWire *_wire;
 
   // Low level communication functions that handle both SPI and I2C.
   void readdata(uint8_t *buff, uint8_t n);


### PR DESCRIPTION
Hi,

this pr add the option to pass a custom I2C instance object instead to use the `Wire` (or `Wire1`) instances.
This allow users to choose which I2C instance to use, in case of platforms with more than a single I2C.
Moreover, an option is also provided to avoid to call the method `.begin()` on the I2C instance, in case it is initialized
by the user code.

The pr is fully backward compatible.

This pull request is somehow related to pr #46 , since the latter performs similar changes to support external SPI declarations.

Regards.
