### PR TITLE
Backdoor Commands for Chinese Mifare tags

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -197,6 +197,11 @@ class Adafruit_PN532{
   // Help functions to display formatted text
   static void PrintHex(const byte * data, const uint32_t numBytes);
   static void PrintHexChar(const byte * pbtData, const uint32_t numBytes);
+  
+  bool ReadRegister(uint8_t* reg, uint8_t* result, uint8_t len);
+  bool WriteRegister(uint8_t* reg, uint8_t len);
+  bool InCommunicateThru(uint8_t* data, uint8_t len);
+  bool UnlockBackdoor();
 
  private:
   uint8_t _ss, _clk, _mosi, _miso;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit PN532
-version=1.0.3
+version=1.0.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for SPI and I2C access to the PN532 RFID/Near Field Communication chip


### PR DESCRIPTION
-This change would add support to the library to unlock the backdoor of special
Mifare tags that allow for reading and writing any block without authenticating

-It shouldn't affect any already existing platforms, just adding more functionality
to them

-I already tested the code and it works correctly, it detects when the tag responds
to the special commands or not

Thank you for considering my pull request, i hope the functionality of these tags is added even if
my pull request is rejected!