### PR TITLE
add constructor accepting Adafruit_SPIDevice

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -142,6 +142,17 @@ Adafruit_PN532::Adafruit_PN532(uint8_t irq, uint8_t reset)
 
 /**************************************************************************/
 /*!
+    @brief  Instantiates a new PN532 class using SPI.
+
+    @param  device       info for SPI bus
+*/
+/**************************************************************************/
+Adafruit_PN532::Adafruit_PN532(Adafruit_SPIDevice device){
+  spi_dev = new Adafruit_SPIDevice(device);
+}
+
+/**************************************************************************/
+/*!
     @brief  Instantiates a new PN532 class using hardware SPI.
 
     @param  ss        SPI chip select pin (CS/SSEL)

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -156,6 +156,7 @@ public:
                  uint8_t ss);                 // Software SPI
   Adafruit_PN532(uint8_t irq, uint8_t reset); // Hardware I2C
   Adafruit_PN532(uint8_t ss);                 // Hardware SPI
+  Adafruit_PN532(Adafruit_SPIDevice device);  // SPI
   void begin(void);
 
   // Generic PN532 functions


### PR DESCRIPTION
I have added a constructor to personalize the frequency of hardware SPI. The issue #80 is still open, so this pull request may help. 

To initialize the PN532 class you will have to type:

    Adafruit_PN532 nfc(Adafruit_SPIDevice(PN532_SS, 100000, SPI_BITORDER_LSBFIRST));
