### PR TITLE
Change constructor to take bus and frequency

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -145,11 +145,13 @@ Adafruit_PN532::Adafruit_PN532(uint8_t irq, uint8_t reset)
     @brief  Instantiates a new PN532 class using hardware SPI.
 
     @param  ss        SPI chip select pin (CS/SSEL)
+    @param  theSPI    The SPI bus to use
+    @param  freq      The clock frequency (in hertz) of the SPI bus
 */
 /**************************************************************************/
-Adafruit_PN532::Adafruit_PN532(uint8_t ss) {
-  spi_dev =
-      new Adafruit_SPIDevice(ss, 1000000, SPI_BITORDER_LSBFIRST, SPI_MODE0);
+Adafruit_PN532::Adafruit_PN532(uint8_t ss, SPIClass *theSPI, uint32_t freq) {
+  spi_dev = new Adafruit_SPIDevice(ss, freq, SPI_BITORDER_LSBFIRST, SPI_MODE0,
+                                   theSPI);
 }
 
 /**************************************************************************/

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -155,7 +155,8 @@ public:
   Adafruit_PN532(uint8_t clk, uint8_t miso, uint8_t mosi,
                  uint8_t ss);                 // Software SPI
   Adafruit_PN532(uint8_t irq, uint8_t reset); // Hardware I2C
-  Adafruit_PN532(uint8_t ss);                 // Hardware SPI
+  Adafruit_PN532(uint8_t ss, SPIClass *theSPI = &SPI,
+                 uint32_t freq = 1000000); // Hardware SPI
   void begin(void);
 
   // Generic PN532 functions


### PR DESCRIPTION
Changes the hardware SPI constructor to take 2 optional parameters: the SPI bus to use and the frequency to run it at.

I created this pull request based on the feedback @fabianoriccardi received on #97. This accepts all user-definable parameters for the SPI bus, while staying in control over the parameters which "just have to be this", like the SPI mode. This way it enables the user to change the bus and the frequency without having to read the datasheet or the other code in this library.