### PR TITLE
Tweak SPI wakeup method to work with cold start

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -156,6 +156,8 @@ Adafruit_PN532::Adafruit_PN532(uint8_t ss) {
 /**************************************************************************/
 /*!
     @brief  Setups the HW
+
+    @returns  true is successful, otherwise false
 */
 /**************************************************************************/
 bool Adafruit_PN532::begin() {

--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -57,17 +57,6 @@
 */
 /**************************************************************************/
 
-#include "Arduino.h"
-
-#include <Wire.h>
-#ifdef __SAM3X8E__ // arduino due
-#define WIRE Wire1 ///< Fixed name for I2C instance
-#else
-#define WIRE Wire ///< Fixed name for I2C instance
-#endif
-
-#include <SPI.h>
-
 #include "Adafruit_PN532.h"
 
 byte pn532ack[] = {0x00, 0x00, 0xFF,
@@ -169,15 +158,12 @@ Adafruit_PN532::Adafruit_PN532(uint8_t ss) {
     @brief  Setups the HW
 */
 /**************************************************************************/
-void Adafruit_PN532::begin() {
-  if (spi_dev != NULL) {
+bool Adafruit_PN532::begin() {
+  if (spi_dev) {
     // SPI initialization
-    spi_dev->begin();
-
-    // not exactly sure why but we have to send a dummy command to get synced up
-    pn532_packetbuffer[0] = PN532_COMMAND_GETFIRMWAREVERSION;
-    sendCommandCheckAck(pn532_packetbuffer, 1);
-    // ignore response!
+    if (!spi_dev->begin()) {
+      return false;
+    }
   } else {
     // I2C initialization.
     WIRE.begin();
@@ -191,6 +177,45 @@ void Adafruit_PN532::begin() {
         10); // Small delay required before taking other actions after reset.
              // See timing diagram on page 209 of the datasheet, section 12.23.
   }
+  reset();  // HW reset - put in known state
+  wakeup(); // hey! wakeup!
+  return true;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Perform a hardware reset. Requires reset pin to have been provided.
+*/
+/**************************************************************************/
+void Adafruit_PN532::reset(void) {
+  // see Datasheet p.209, Fig.48 for timings
+  if (_reset != -1) {
+    digitalWrite(_reset, LOW);
+    delay(1); // min 20ns
+    digitalWrite(_reset, HIGH);
+    delay(2); // max 2ms
+  }
+}
+
+/**************************************************************************/
+/*!
+    @brief  Wakeup from LowVbat mode into Normal Mode.
+*/
+/**************************************************************************/
+void Adafruit_PN532::wakeup(void) {
+  // interface specific wakeups - each one is unique!
+  if (spi_dev != NULL) {
+    // hold CS low for 2ms
+    spi_dev->beginTransactionWithAssertingCS();
+    delay(2);
+  }
+
+  //
+  // TODO:: add I2C and HSU (uart) specific wakeups
+  //
+
+  // need to config SAM to stay in Normal Mode
+  SAMConfig();
 }
 
 /**************************************************************************/

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -14,6 +14,14 @@
 #define ADAFRUIT_PN532_H
 
 #include "Arduino.h"
+
+#include <Wire.h>
+#ifdef __SAM3X8E__ // arduino due
+#define WIRE Wire1 ///< Fixed name for I2C instance
+#else
+#define WIRE Wire ///< Fixed name for I2C instance
+#endif
+
 #include <Adafruit_SPIDevice.h>
 
 #define PN532_PREAMBLE (0x00)   ///< Command sequence start, byte 1/3
@@ -142,7 +150,10 @@ public:
                  uint8_t ss);                 // Software SPI
   Adafruit_PN532(uint8_t irq, uint8_t reset); // Hardware I2C
   Adafruit_PN532(uint8_t ss);                 // Hardware SPI
-  void begin(void);
+  bool begin(void);
+
+  void reset(void);
+  void wakeup(void);
 
   // Generic PN532 functions
   bool SAMConfig(void);


### PR DESCRIPTION
Tweaks the SPI initialization to work better on cold start. The approach taken is based on the PN532 User Manual, s6.3.4.3, for the variant without using `H_REQ` pin (aka `P32_INT0` in Datasheet).

![image](https://user-images.githubusercontent.com/8755041/218609198-c4499dfe-ee08-4768-946c-acb982d01fd1.png)

With `readMifare` example loaded on a Feather M4 Express. Remove power. Plug USB cable back in. Open Serial Monitor.
 
**BEFORE** (note - warm start worked with old code)
![Screenshot from 2023-02-13 16-31-41](https://user-images.githubusercontent.com/8755041/218609523-6342dff1-a504-4a9e-a571-80bc982970c5.png)

**AFTER**
![Screenshot from 2023-02-13 16-32-28](https://user-images.githubusercontent.com/8755041/218609708-1674906e-02cf-4cc4-9a3d-fab67cab7c21.png)

Summary of changes:
* added new `reset()` and `wakeup()` methods
* both are now called from `begin()`
* removed old SPI "wakeup" code that was in `begin()`
* moved `#inc` to header file and other misc cleanup
