### PR TITLE
Add HSU Support

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -144,7 +144,8 @@ public:
                  uint8_t ss); // Software SPI
   Adafruit_PN532(uint8_t ss); // Hardware SPI
   Adafruit_PN532(uint8_t irq, uint8_t reset,
-                 TwoWire *theWire = &Wire); // Hardware I2C
+                 TwoWire *theWire = &Wire);              // Hardware I2C
+  Adafruit_PN532(uint8_t reset, HardwareSerial *theSer); // Hardware UART
   bool begin(void);
 
   void reset(void);
@@ -214,6 +215,7 @@ private:
 
   Adafruit_SPIDevice *spi_dev = NULL;
   Adafruit_I2CDevice *i2c_dev = NULL;
+  HardwareSerial *ser_dev = NULL;
 };
 
 #endif

--- a/examples/readMifare/readMifare.ino
+++ b/examples/readMifare/readMifare.ino
@@ -1,20 +1,20 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     readMifare.pde
     @author   Adafruit Industries
 	@license  BSD (see license.txt)
 
     This example will wait for any ISO14443A card or tag, and
     depending on the size of the UID will attempt to read from it.
-   
+
     If the card has a 4-byte UID it is probably a Mifare
     Classic card, and the following steps are taken:
-   
+
     - Authenticate block 4 (the first block of Sector 1) using
       the default KEYA of 0XFF 0XFF 0XFF 0XFF 0XFF 0XFF
     - If authentication succeeds, we can then read any of the
       4 blocks in that sector (though only block 4 is read here)
-	 
+
     If the card has a 7-byte UID it is probably a Mifare
     Ultralight card, and the 4 byte pages can be read directly.
     Page 4 is read by default since this is the first 'general-
@@ -22,14 +22,14 @@
 
 
 This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-This library works with the Adafruit NFC breakout 
+This library works with the Adafruit NFC breakout
   ----> https://www.adafruit.com/products/364
- 
-Check out the links above for our tutorials and wiring diagrams 
+
+Check out the links above for our tutorials and wiring diagrams
 These chips use SPI or I2C to communicate.
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
 */
@@ -64,6 +64,8 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 // Or use this line for a breakout or shield with an I2C connection:
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
+// Or use hardware Serial:
+//Adafruit_PN532 nfc(PN532_RESET, &Serial1);
 
 void setup(void) {
   Serial.begin(115200);
@@ -79,13 +81,13 @@ void setup(void) {
     while (1); // halt
   }
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
+
   // configure board to read RFID tags
   nfc.SAMConfig();
-  
+
   Serial.println("Waiting for an ISO14443A Card ...");
 }
 
@@ -94,12 +96,12 @@ void loop(void) {
   uint8_t success;
   uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
   uint8_t uidLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
-    
+
   // Wait for an ISO14443A type cards (Mifare, etc.).  When one is found
   // 'uid' will be populated with the UID, and uidLength will indicate
   // if the uid is 4 bytes (Mifare Classic) or 7 bytes (Mifare Ultralight)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
-  
+
   if (success) {
     // Display some basic information about the card
     Serial.println("Found an ISO14443A card");
@@ -107,27 +109,27 @@ void loop(void) {
     Serial.print("  UID Value: ");
     nfc.PrintHex(uid, uidLength);
     Serial.println("");
-    
+
     if (uidLength == 4)
     {
-      // We probably have a Mifare Classic card ... 
+      // We probably have a Mifare Classic card ...
       Serial.println("Seems to be a Mifare Classic card (4 byte UID)");
-	  
+
       // Now we need to try to authenticate it for read/write access
       // Try with the factory default KeyA: 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF
       Serial.println("Trying to authenticate block 4 with default KEYA value");
       uint8_t keya[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-	  
+
 	  // Start with block 4 (the first block of sector 1) since sector 0
 	  // contains the manufacturer data and it's probably better just
 	  // to leave it alone unless you know what you're doing
       success = nfc.mifareclassic_AuthenticateBlock(uid, uidLength, 4, 0, keya);
-	  
+
       if (success)
       {
         Serial.println("Sector 1 (Blocks 4..7) has been authenticated");
         uint8_t data[16];
-		
+
         // If you want to write something to block 4 to test with, uncomment
 		// the following line and this text should be read back in a minute
         //memcpy(data, (const uint8_t[]){ 'a', 'd', 'a', 'f', 'r', 'u', 'i', 't', '.', 'c', 'o', 'm', 0, 0, 0, 0 }, sizeof data);
@@ -135,14 +137,14 @@ void loop(void) {
 
         // Try to read the contents of block 4
         success = nfc.mifareclassic_ReadDataBlock(4, data);
-		
+
         if (success)
         {
           // Data seems to have been read ... spit it out
           Serial.println("Reading Block 4:");
           nfc.PrintHexChar(data, 16);
           Serial.println("");
-		  
+
           // Wait a bit before reading the card again
           delay(1000);
         }
@@ -156,12 +158,12 @@ void loop(void) {
         Serial.println("Ooops ... authentication failed: Try another key?");
       }
     }
-    
+
     if (uidLength == 7)
     {
       // We probably have a Mifare Ultralight card ...
       Serial.println("Seems to be a Mifare Ultralight tag (7 byte UID)");
-	  
+
       // Try to read the first general-purpose user page (#4)
       Serial.println("Reading page 4");
       uint8_t data[32];
@@ -171,7 +173,7 @@ void loop(void) {
         // Data seems to have been read ... spit it out
         nfc.PrintHexChar(data, 4);
         Serial.println("");
-		
+
         // Wait a bit before reading the card again
         delay(1000);
       }


### PR DESCRIPTION
Adds support for HSU interface, aka Serial, aka UART.

**Only Hardware Serial support at this point.**

Other notes:
* Removed "wait for a card" loop in `readPassiveTargetID`. Should be OK to just read the response frame and rely on `readDetectedPassiveTargetID` which checks the number of targets detected in the response frame and just returns if 0. This could have been part of a previous PR. Adding UART just exposed it.
* Fixed a couple of off-by-one in reading response length. SPI and I2C were tolerant of this as each's "stop" would throw away any unread data. The unread data was the meaningless end of frame 0x00 postamble, so also was not critical information being lost. For UART, unread data remains in buffer which throws off the next read, since that left over data is not expected. (may be others?)

Tested with updated `readMifare` example on Feather M4 using the new constructor:
```cpp
Adafruit_PN532 nfc(PN532_RESET, &Serial1);
```
![Screenshot from 2023-02-15 09-45-00](https://user-images.githubusercontent.com/8755041/219114380-6b8fbc8f-e2a9-4ddf-be7b-2bf381d3dbde.png)



**Also retested SPI:**
![Screenshot from 2023-02-15 09-48-46](https://user-images.githubusercontent.com/8755041/219114411-b9a82c35-2340-4b0c-bb3e-299ebff617b3.png)


**Also retested I2C:**
![Screenshot from 2023-02-15 09-52-19](https://user-images.githubusercontent.com/8755041/219114439-d94127d2-76f7-4f2a-8b2f-cc7906804d64.png)
