### PR TITLE
Minor tweaks based on BSP run thru (SAMD, ESP32, ESP8266, RP2040)

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -91,6 +91,7 @@ byte pn532_packetbuffer[PN532_PACKBUFFSIZ]; ///< Packet buffer used in various
 /**************************************************************************/
 Adafruit_PN532::Adafruit_PN532(uint8_t clk, uint8_t miso, uint8_t mosi,
                                uint8_t ss) {
+  _cs = ss;
   spi_dev = new Adafruit_SPIDevice(ss, clk, miso, mosi, 1000000,
                                    SPI_BITORDER_LSBFIRST, SPI_MODE0);
 }
@@ -119,6 +120,7 @@ Adafruit_PN532::Adafruit_PN532(uint8_t irq, uint8_t reset, TwoWire *theWire)
 */
 /**************************************************************************/
 Adafruit_PN532::Adafruit_PN532(uint8_t ss) {
+  _cs = ss;
   spi_dev =
       new Adafruit_SPIDevice(ss, 1000000, SPI_BITORDER_LSBFIRST, SPI_MODE0);
 }
@@ -158,6 +160,9 @@ bool Adafruit_PN532::begin() {
     }
   } else if (ser_dev) {
     ser_dev->begin(115200);
+    // clear out anything in read buffer
+    while (ser_dev->available())
+      ser_dev->read();
   } else {
     // no interface specified
     return false;
@@ -192,7 +197,7 @@ void Adafruit_PN532::wakeup(void) {
   // interface specific wakeups - each one is unique!
   if (spi_dev) {
     // hold CS low for 2ms
-    spi_dev->beginTransactionWithAssertingCS();
+    digitalWrite(_cs, LOW);
     delay(2);
   } else if (ser_dev) {
     uint8_t w[3] = {0x55, 0x00, 0x00};

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -200,7 +200,7 @@ public:
   static void PrintHexChar(const byte *pbtData, const uint32_t numBytes);
 
 private:
-  int8_t _irq = -1, _reset = -1;
+  int8_t _irq = -1, _reset = -1, _cs = -1;
   int8_t _uid[7];      // ISO14443A uid
   int8_t _uidLen;      // uid len
   int8_t _key[6];      // Mifare Classic key

--- a/examples/readMifare/readMifare.ino
+++ b/examples/readMifare/readMifare.ino
@@ -85,9 +85,6 @@ void setup(void) {
   Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
 
-  // configure board to read RFID tags
-  nfc.SAMConfig();
-
   Serial.println("Waiting for an ISO14443A Card ...");
 }
 


### PR DESCRIPTION
Just a few tweaks based on running through a set of BSPs to test each PN532 interface.

Tested using updated `readMifare` example in this PR. The only change to example is removal of call to `SAMConfig()` from user sketch, since this is now done internally in `Adafruit_PN532::begin()`. (other examples should be updated also)

The following BSPs were tested:
* SAMD - Feather M4 Express
* ESP32 - Feather ESP32 V2
* ESP8266 - Feather ESP8266
* RP2040 (philhower) - Feather RP2040

The following PN532 interfaces were tested on each of the above:
* SPI
* I2C
* HSU (serial)

Results:
* ESP32 did not like using `spi_dev->beginTransactionWithAssertingCS()` for SPI wakeup. Switched to directly setting CS pin.
* RP2040 w/HSU wanted serial read buffer cleared out before usage
* RP2040 w/SPI required fixing a bug in RP2040 BSP when using LSBFIRST 
* Feather ESP8266 has no extra hardware Serial, so PN532 HSU interface did not work
* All other combos worked
