### PR TITLE
Add alternate SPI and some misc clean up

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -117,12 +117,13 @@ Adafruit_PN532::Adafruit_PN532(uint8_t irq, uint8_t reset, TwoWire *theWire)
     @brief  Instantiates a new PN532 class using hardware SPI.
 
     @param  ss        SPI chip select pin (CS/SSEL)
+    @param  theSPI    pointer to the SPI bus to use
 */
 /**************************************************************************/
-Adafruit_PN532::Adafruit_PN532(uint8_t ss) {
+Adafruit_PN532::Adafruit_PN532(uint8_t ss, SPIClass *theSPI) {
   _cs = ss;
-  spi_dev =
-      new Adafruit_SPIDevice(ss, 1000000, SPI_BITORDER_LSBFIRST, SPI_MODE0);
+  spi_dev = new Adafruit_SPIDevice(ss, 1000000, SPI_BITORDER_LSBFIRST,
+                                   SPI_MODE0, theSPI);
 }
 
 /**************************************************************************/

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -141,8 +141,8 @@
 class Adafruit_PN532 {
 public:
   Adafruit_PN532(uint8_t clk, uint8_t miso, uint8_t mosi,
-                 uint8_t ss); // Software SPI
-  Adafruit_PN532(uint8_t ss); // Hardware SPI
+                 uint8_t ss);                          // Software SPI
+  Adafruit_PN532(uint8_t ss, SPIClass *theSPI = &SPI); // Hardware SPI
   Adafruit_PN532(uint8_t irq, uint8_t reset,
                  TwoWire *theWire = &Wire);              // Hardware I2C
   Adafruit_PN532(uint8_t reset, HardwareSerial *theSer); // Hardware UART

--- a/README.md
+++ b/README.md
@@ -2,47 +2,13 @@
 
 
 This is a library for the Adafruit PN532 NFC/RFID breakout boards
-This library works with the Adafruit NFC breakout 
+This library works with the Adafruit NFC breakout
 
   * https://www.adafruit.com/products/364
- 
-Check out the links above for our tutorials and wiring diagrams 
+
+Check out the links above for our tutorials and wiring diagrams
 These chips use I2C or SPI to communicate.
 
-
-<!-- START COMPATIBILITY TABLE -->
-
-## Compatibility
-
-MCU                | Tested Works | Doesn't Work | Not Tested  | Notes
------------------- | :----------: | :----------: | :---------: | -----
-Atmega328 @ 16MHz  |      X       |             |            | SPI &amp; I2C Works
-Atmega328 @ 12MHz  |      X       |             |            | SPI &amp; I2C Works
-Atmega32u4 @ 16MHz |      X       |             |            | Follow instructions at https://learn.adafruit.com/adafruit-pn532-rfid-nfc/shield-wiring#using-with-the-arduino-leonardo-and-yun to move pin 2.
-Atmega32u4 @ 8MHz  |      X       |             |            | SPI &amp; I2C Works
-ESP8266            |             |      X       |            | SPI only, I2C clock stretching not supported
-ESP32              |      X       |             |            | SPI works; I2C works using IRQ and without sharing the I2C bus.
-Atmega2560 @ 16MHz |      X       |             |            | SPI &amp; I2C Works
-ATSAM3X8E          |      X       |             |            | SPI &amp; I2C Works
-ATSAM21D           |             |      X       |            | SPI only, I2C clock stretching not supported. Use programming port.
-ATtiny85 @ 16MHz   |             |             |     X       | 
-ATtiny85 @ 8MHz    |             |             |     X       | 
-Intel Curie @ 32MHz |             |             |     X       | 
-STM32F2            |             |             |     X       | 
-
-  * ATmega328 @ 16MHz : Arduino UNO, Adafruit Pro Trinket 5V, Adafruit Metro 328, Adafruit Metro Mini
-  * ATmega328 @ 12MHz : Adafruit Pro Trinket 3V
-  * ATmega32u4 @ 16MHz : Arduino Leonardo, Arduino Micro, Arduino Yun, Teensy 2.0
-  * ATmega32u4 @ 8MHz : Adafruit Flora, Bluefruit Micro
-  * ESP8266 : Adafruit Huzzah
-  * ESP32 : WROOM
-  * ATmega2560 @ 16MHz : Arduino Mega
-  * ATSAM3X8E : Arduino Due
-  * ATSAM21D : Arduino Zero, M0 Pro
-  * ATtiny85 @ 16MHz : Adafruit Trinket 5V
-  * ATtiny85 @ 8MHz : Adafruit Gemma, Arduino Gemma, Adafruit Trinket 3V
-
-<!-- END COMPATIBILITY TABLE -->
 # Dependencies
 * [Adafruit_BusIO](https://github.com/adafruit/Adafruit_BusIO)
 
@@ -76,11 +42,11 @@ Note that the formatting output by `clang-format` is what the automated formatti
 ### clang-format resources
   * [Binary builds and source available on the LLVM downloads page](https://releases.llvm.org/download.html)
   * [Documentation and IDE integration](https://clang.llvm.org/docs/ClangFormat.html)
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada & Kevin Townsend for Adafruit Industries.  
+Written by Limor Fried/Ladyada & Kevin Townsend for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above must be included in any redistribution
 

--- a/examples/apduToBlackBerry/apduToBlackBerry.ino
+++ b/examples/apduToBlackBerry/apduToBlackBerry.ino
@@ -1,12 +1,12 @@
-/**  
+/**
    Copyright (c) 2011, 2012, 2013 Research In Motion Limited.
-  
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-  
+
    http://www.apache.org/licenses/LICENSE-2.0
-  
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -81,15 +81,12 @@ void setup() {
     }
   }
 
-  Serial.print("Found chip PN5"); 
-  Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); 
-  Serial.print((versiondata>>16) & 0xFF, DEC); 
-  Serial.print('.'); 
+  Serial.print("Found chip PN5");
+  Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. ");
+  Serial.print((versiondata>>16) & 0xFF, DEC);
+  Serial.print('.');
   Serial.println((versiondata>>8) & 0xFF, DEC);
-
-  // configure board to read RFID tags
-  nfc.SAMConfig();
 
   nfc.begin();
 }
@@ -126,7 +123,7 @@ void loop(void) {
             //  Serial.print(' ');
             //}
             //Serial.println();
-          } 
+          }
           else {
             //Serial.println("Doesn't seem to be a color...");
           }
@@ -137,13 +134,13 @@ void loop(void) {
           ;
         }
         delay(10);
-      } 
+      }
       else {
         //Serial.println("It's gone...");
         break;
       }
     }
-  } 
+  }
   else {
     //Serial.print("Trying again...");
   }

--- a/examples/iso14443a_uid/iso14443a_uid.ino
+++ b/examples/iso14443a_uid/iso14443a_uid.ino
@@ -1,25 +1,25 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     iso14443a_uid.pde
     @author   Adafruit Industries
 	@license  BSD (see license.txt)
 
     This example will attempt to connect to an ISO14443A
     card or tag and retrieve some basic information about it
-    that can be used to determine what type of card it is.   
-   
+    that can be used to determine what type of card it is.
+
     Note that you need the baud rate to be 115200 because we need to print
 	out the data and read from the card at the same time!
 
 This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-This library works with the Adafruit NFC breakout 
+This library works with the Adafruit NFC breakout
   ----> https://www.adafruit.com/products/364
- 
-Check out the links above for our tutorials and wiring diagrams 
+
+Check out the links above for our tutorials and wiring diagrams
 These chips use SPI or I2C to communicate.
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
 */
@@ -66,20 +66,17 @@ void setup(void) {
     Serial.print("Didn't find PN53x board");
     while (1); // halt
   }
-  
+
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
+
   // Set the max number of retry attempts to read from a card
   // This prevents us from waiting forever for a card, which is
   // the default behaviour of the PN532.
   nfc.setPassiveActivationRetries(0xFF);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
-  
+
   Serial.println("Waiting for an ISO14443A card");
 }
 
@@ -87,19 +84,19 @@ void loop(void) {
   boolean success;
   uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };	// Buffer to store the returned UID
   uint8_t uidLength;				// Length of the UID (4 or 7 bytes depending on ISO14443A card type)
-  
+
   // Wait for an ISO14443A type cards (Mifare, etc.).  When one is found
   // 'uid' will be populated with the UID, and uidLength will indicate
   // if the uid is 4 bytes (Mifare Classic) or 7 bytes (Mifare Ultralight)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, &uid[0], &uidLength);
-  
+
   if (success) {
     Serial.println("Found a card!");
     Serial.print("UID Length: ");Serial.print(uidLength, DEC);Serial.println(" bytes");
     Serial.print("UID Value: ");
-    for (uint8_t i=0; i < uidLength; i++) 
+    for (uint8_t i=0; i < uidLength; i++)
     {
-      Serial.print(" 0x");Serial.print(uid[i], HEX); 
+      Serial.print(" 0x");Serial.print(uid[i], HEX);
     }
     Serial.println("");
 	// Wait 1 second before continuing

--- a/examples/iso14443as_target/iso14443as_target.ino
+++ b/examples/iso14443as_target/iso14443as_target.ino
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     iso14443as_target.pde
     @original Adafruit Industries
     @modified Salvador Mendoza(@Netxing)
@@ -7,20 +7,20 @@
 
     This example will attempt to mimic an ISO14443A smart card
     and retrieve some basic information from a PoS or terminal,
-    this can be used to establish a communication process.   
-   
+    this can be used to establish a communication process.
+
     Note that you need the baud rate to be 115200 because we need to print
     out the data and read from the card at the same time!
 
 This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-This library works with the Adafruit NFC breakout 
+This library works with the Adafruit NFC breakout
   ----> https://www.adafruit.com/products/364
- 
-Check out the links above for our tutorials and wiring diagrams 
+
+Check out the links above for our tutorials and wiring diagrams
 These chips use SPI or I2C to communicate.
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
 */
@@ -68,20 +68,17 @@ void setup(void) {
     Serial.print("Didn't find PN53x board");
     while (1); // halt
   }
-  
+
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
+
   // Set the max number of retry attempts to read from a card
   // This prevents us from waiting forever for a card, which is
   // the default behaviour of the PN532.
   nfc.setPassiveActivationRetries(0xFF);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
-  
+
   Serial.println("As Target... Approach the NFC PN532 Board to a PoS or terminal!");
   delay(200);
 }

--- a/examples/mifareclassic_formatndef/mifareclassic_formatndef.ino
+++ b/examples/mifareclassic_formatndef/mifareclassic_formatndef.ino
@@ -92,9 +92,6 @@ void setup(void) {
   Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
   Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-
-  // configure board to read RFID tags
-  nfc.SAMConfig();
 }
 
 void loop(void) {

--- a/examples/mifareclassic_memdump/mifareclassic_memdump.ino
+++ b/examples/mifareclassic_memdump/mifareclassic_memdump.ino
@@ -72,9 +72,6 @@ void setup(void) {
   Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
 
-  // configure board to read RFID tags
-  nfc.SAMConfig();
-
   Serial.println("Waiting for an ISO14443A Card ...");
 }
 

--- a/examples/mifareclassic_ndeftoclassic/mifareclassic_ndeftoclassic.ino
+++ b/examples/mifareclassic_ndeftoclassic/mifareclassic_ndeftoclassic.ino
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     mifareclassic_ndeftoclassic.pde
     @author   KTOWN (Adafruit Industries)
   	@license  BSD (see license.txt)
@@ -9,14 +9,14 @@
     the authentication keys back to the Mifare Classic defaults
 
     This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-    This library works with the Adafruit NFC Shield 
+    This library works with the Adafruit NFC Shield
       ----> https://www.adafruit.com/products/789
- 
-    Check out the links above for our tutorials and wiring diagrams 
+
+    Check out the links above for our tutorials and wiring diagrams
     These chips use SPI or I2C to communicate
 
-    Adafruit invests time and resources providing this open source code, 
-    please support Adafruit and open-source hardware by purchasing 
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
     products from Adafruit!
 
 */
@@ -84,14 +84,11 @@ void setup(void) {
     Serial.print("Didn't find PN53x board");
     while (1); // halt
   }
-  
+
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
 }
 
 void loop(void) {
@@ -102,20 +99,20 @@ void loop(void) {
   uint8_t blankAccessBits[3] = { 0xff, 0x07, 0x80 };
   uint8_t idx = 0;
   uint8_t numOfSector = 16;                 // Assume Mifare Classic 1K for now (16 4-block sectors)
-  
+
   Serial.println("Place your NDEF formatted Mifare Classic 1K card on the reader");
   Serial.println("and press any key to continue ...");
-  
+
   // Wait for user input before proceeding
   while (!Serial.available());
   while (Serial.available()) Serial.read();
-    
+
   // Wait for an ISO14443A type card (Mifare, etc.).  When one is found
   // 'uid' will be populated with the UID, and uidLength will indicate
   // if the uid is 4 bytes (Mifare Classic) or 7 bytes (Mifare Ultralight)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
 
-  if (success) 
+  if (success)
   {
     // We seem to have a tag ...
     // Display some basic information about it
@@ -124,14 +121,14 @@ void loop(void) {
     Serial.print("  UID Value: ");
     nfc.PrintHex(uid, uidLength);
     Serial.println("");
-    
+
     // Make sure this is a Mifare Classic card
     if (uidLength != 4)
     {
-      Serial.println("Ooops ... this doesn't seem to be a Mifare Classic card!"); 
+      Serial.println("Ooops ... this doesn't seem to be a Mifare Classic card!");
       return;
-    }    
-    
+    }
+
     Serial.println("Seems to be a Mifare Classic card (4 byte UID)");
     Serial.println("");
     Serial.println("Reformatting card for Mifare Classic (please don't touch it!) ... ");
@@ -146,7 +143,7 @@ void loop(void) {
         Serial.print("Authentication failed for sector "); Serial.println(numOfSector);
         return;
       }
-      
+
       // Step 2: Write to the other blocks
       if (idx == 16)
       {
@@ -186,7 +183,7 @@ void loop(void) {
         Serial.print("Unable to write to sector "); Serial.println(numOfSector);
         return;
       }
-      
+
       // Step 3: Reset both keys to 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF
       memcpy(blockBuffer, KEY_DEFAULT_KEYAB, sizeof(KEY_DEFAULT_KEYAB));
       memcpy(blockBuffer + 6, blankAccessBits, sizeof(blankAccessBits));
@@ -201,7 +198,7 @@ void loop(void) {
       }
     }
   }
-  
+
   // Wait a bit before trying again
   Serial.println("\n\nDone!");
   delay(1000);

--- a/examples/mifareclassic_updatendef/mifareclassic_updatendef.ino
+++ b/examples/mifareclassic_updatendef/mifareclassic_updatendef.ino
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     mifareclassic_updatendef.pde
     @author   Adafruit Industries
   	@license  BSD (see license.txt)
@@ -8,14 +8,14 @@
     mifareclassic_formatndef.pde for example), inserting a new url
 
     This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-    This library works with the Adafruit NFC Shield 
+    This library works with the Adafruit NFC Shield
       ----> https://www.adafruit.com/products/789
- 
-    Check out the links above for our tutorials and wiring diagrams 
+
+    Check out the links above for our tutorials and wiring diagrams
     These chips use SPI or I2C to communicate
 
-    Adafruit invests time and resources providing this open source code, 
-    please support Adafruit and open-source hardware by purchasing 
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
     products from Adafruit!
 
 */
@@ -51,11 +51,11 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 // Or use this line for a breakout or shield with an I2C connection:
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
-/*  
+/*
     We can encode many different kinds of pointers to the card,
     from a URL, to an Email address, to a phone number, and many more
     check the library header .h file to see the large # of supported
-    prefixes! 
+    prefixes!
 */
 // For a http://www. url:
 const char * url = "adafruit.com/blog/";
@@ -83,14 +83,11 @@ void setup(void) {
     Serial.print("Didn't find PN53x board");
     while (1); // halt
   }
-  
+
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
 }
 
 void loop(void) {
@@ -107,13 +104,13 @@ void loop(void) {
   while (!Serial.available());
   // a key was pressed1
   while (Serial.available()) Serial.read();
-    
+
   // Wait for an ISO14443A type card (Mifare, etc.).  When one is found
   // 'uid' will be populated with the UID, and uidLength will indicate
   // if the uid is 4 bytes (Mifare Classic) or 7 bytes (Mifare Ultralight)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
-  
-  if (success) 
+
+  if (success)
   {
     // Display some basic information about the card
     Serial.println("Found an ISO14443A card");
@@ -121,15 +118,15 @@ void loop(void) {
     Serial.print("  UID Value: ");
     nfc.PrintHex(uid, uidLength);
     Serial.println("");
-    
+
     // Make sure this is a Mifare Classic card
     if (uidLength != 4)
     {
-      Serial.println("Ooops ... this doesn't seem to be a Mifare Classic card!"); 
+      Serial.println("Ooops ... this doesn't seem to be a Mifare Classic card!");
       return;
     }
-    
-    // We probably have a Mifare Classic card ... 
+
+    // We probably have a Mifare Classic card ...
     Serial.println("Seems to be a Mifare Classic card (4 byte UID)");
 
     // Check if this is an NDEF card (using first block of sector 1 from mifareclassic_formatndef.pde)
@@ -140,7 +137,7 @@ void loop(void) {
       Serial.println("Unable to authenticate block 4 ... is this card NDEF formatted?");
       return;
     }
-    
+
     Serial.println("Authentication succeeded (seems to be an NDEF/NFC Forum tag) ...");
 
     // Authenticated seems to have worked
@@ -156,22 +153,22 @@ void loop(void) {
       Serial.println("URI is too long ... must be less than 38 characters!");
       return;
     }
-    
+
     Serial.println("Updating sector 1 with URI as NDEF Message");
-    
+
     // URI is within size limits ... write it to the card and report success/failure
     success = nfc.mifareclassic_WriteNDEFURI(1, ndefprefix, url);
     if (success)
     {
       Serial.println("NDEF URI Record written to sector 1");
-      Serial.println("");      
+      Serial.println("");
     }
     else
     {
       Serial.println("NDEF Record creation failed! :(");
     }
   }
-  
+
   // Wait a bit before trying again
   Serial.println("\n\nDone!");
   delay(1000);

--- a/examples/ntag2xx_erase/ntag2xx_erase.ino
+++ b/examples/ntag2xx_erase/ntag2xx_erase.ino
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     ntag2xx_erase.pde
     @author   KTOWN (Adafruit Industries)
     @license  BSD (see license.txt)
@@ -9,14 +9,14 @@
     all user bytes to 0x00)
 
     This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-    This library works with the Adafruit NFC breakout 
+    This library works with the Adafruit NFC breakout
       ----> https://www.adafruit.com/products/364
- 
-    Check out the links above for our tutorials and wiring diagrams 
+
+    Check out the links above for our tutorials and wiring diagrams
     These chips use SPI or I2C to communicate.
 
-    Adafruit invests time and resources providing this open source code, 
-    please support Adafruit and open-source hardware by purchasing 
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
     products from Adafruit!
 */
 /**************************************************************************/
@@ -64,13 +64,10 @@ void setup(void) {
     while (1); // halt
   }
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
-  
+
   Serial.println("Waiting for an ISO14443A Card ...");
 }
 
@@ -78,11 +75,11 @@ void loop(void) {
   uint8_t success;
   uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
   uint8_t uidLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
-    
+
   // Wait for an NTAG203 card.  When one is found 'uid' will be populated with
   // the UID, and uidLength will indicate the size of the UUID (normally 7)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
-  
+
   if (success) {
     // Display some basic information about the card
     Serial.println("Found an ISO14443A card");
@@ -90,18 +87,18 @@ void loop(void) {
     Serial.print("  UID Value: ");
     nfc.PrintHex(uid, uidLength);
     Serial.println("");
-    
+
     if (uidLength == 7)
     {
       uint8_t data[32];
-      
+
       // We probably have an NTAG2xx card (though it could be Ultralight as well)
-      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");	  
-      
+      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");
+
       // NTAG2x3 cards have 39*4 bytes of user pages (156 user bytes),
       // starting at page 4 ... larger cards just add pages to the end of
       // this range:
-      
+
       // See: http://www.nxp.com/documents/short_data_sheet/NTAG203_SDS.pdf
 
       // TAG Type       PAGES   USER START    USER STOP
@@ -109,16 +106,16 @@ void loop(void) {
       // NTAG 203       42      4             39
       // NTAG 213       45      4             39
       // NTAG 215       135     4             129
-      // NTAG 216       231     4             225      
+      // NTAG 216       231     4             225
 
       Serial.println("");
       Serial.println("Writing 0x00 0x00 0x00 0x00 to pages 4..39");
       Serial.println("");
-      for (uint8_t i = 4; i < 39; i++) 
+      for (uint8_t i = 4; i < 39; i++)
       {
         memset(data, 0, 4);
         success = nfc.ntag2xx_WritePage(i, data);
-        
+
         // Display the current page number
         Serial.print("Page ");
         if (i < 10)
@@ -133,7 +130,7 @@ void loop(void) {
         Serial.print(": ");
 
         // Display the results, depending on 'success'
-        if (success) 
+        if (success)
         {
           Serial.println("Erased");
         }
@@ -141,13 +138,13 @@ void loop(void) {
         {
           Serial.println("Unable to write to the requested page!");
         }
-      }      
+      }
     }
     else
     {
       Serial.println("This doesn't seem to be an NTAG203 tag (UUID length != 7 bytes)!");
     }
-    
+
     // Wait a bit before trying again
     Serial.println("\n\nSend a character to scan another tag!");
     Serial.flush();
@@ -155,7 +152,7 @@ void loop(void) {
     while (Serial.available()) {
     Serial.read();
     }
-    Serial.flush();    
+    Serial.flush();
   }
 }
 

--- a/examples/ntag2xx_read/ntag2xx_read.ino
+++ b/examples/ntag2xx_read/ntag2xx_read.ino
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     readntag203.pde
     @author   KTOWN (Adafruit Industries)
     @license  BSD (see license.txt)
@@ -8,14 +8,14 @@
     and will attempt to read from it.
 
     This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-    This library works with the Adafruit NFC breakout 
+    This library works with the Adafruit NFC breakout
       ----> https://www.adafruit.com/products/364
- 
-    Check out the links above for our tutorials and wiring diagrams 
+
+    Check out the links above for our tutorials and wiring diagrams
     These chips use SPI or I2C to communicate.
 
-    Adafruit invests time and resources providing this open source code, 
-    please support Adafruit and open-source hardware by purchasing 
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
     products from Adafruit!
 */
 /**************************************************************************/
@@ -64,13 +64,10 @@ void setup(void) {
     while (1); // halt
   }
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
-  
+
   Serial.println("Waiting for an ISO14443A Card ...");
 }
 
@@ -78,11 +75,11 @@ void loop(void) {
   uint8_t success;
   uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
   uint8_t uidLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
-    
+
   // Wait for an NTAG203 card.  When one is found 'uid' will be populated with
   // the UID, and uidLength will indicate the size of the UUID (normally 7)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
-  
+
   if (success) {
     // Display some basic information about the card
     Serial.println("Found an ISO14443A card");
@@ -90,18 +87,18 @@ void loop(void) {
     Serial.print("  UID Value: ");
     nfc.PrintHex(uid, uidLength);
     Serial.println("");
-    
+
     if (uidLength == 7)
     {
       uint8_t data[32];
-      
+
       // We probably have an NTAG2xx card (though it could be Ultralight as well)
-      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");	  
-      
+      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");
+
       // NTAG2x3 cards have 39*4 bytes of user pages (156 user bytes),
       // starting at page 4 ... larger cards just add pages to the end of
       // this range:
-      
+
       // See: http://www.nxp.com/documents/short_data_sheet/NTAG203_SDS.pdf
 
       // TAG Type       PAGES   USER START    USER STOP
@@ -109,12 +106,12 @@ void loop(void) {
       // NTAG 203       42      4             39
       // NTAG 213       45      4             39
       // NTAG 215       135     4             129
-      // NTAG 216       231     4             225      
+      // NTAG 216       231     4             225
 
-      for (uint8_t i = 0; i < 42; i++) 
+      for (uint8_t i = 0; i < 42; i++)
       {
         success = nfc.ntag2xx_ReadPage(i, data);
-        
+
         // Display the current page number
         Serial.print("PAGE ");
         if (i < 10)
@@ -129,7 +126,7 @@ void loop(void) {
         Serial.print(": ");
 
         // Display the results, depending on 'success'
-        if (success) 
+        if (success)
         {
           // Dump the page data
           nfc.PrintHexChar(data, 4);
@@ -138,13 +135,13 @@ void loop(void) {
         {
           Serial.println("Unable to read the requested page!");
         }
-      }      
+      }
     }
     else
     {
       Serial.println("This doesn't seem to be an NTAG203 tag (UUID length != 7 bytes)!");
     }
-    
+
     // Wait a bit before trying again
     Serial.println("\n\nSend a character to scan another tag!");
     Serial.flush();
@@ -152,7 +149,7 @@ void loop(void) {
     while (Serial.available()) {
     Serial.read();
     }
-    Serial.flush();    
+    Serial.flush();
   }
 }
 

--- a/examples/ntag2xx_updatendef/ntag2xx_updatendef.ino
+++ b/examples/ntag2xx_updatendef/ntag2xx_updatendef.ino
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     ntag2xx_updatendef.pde
     @author   KTOWN (Adafruit Industries)
     @license  BSD (see license.txt)
@@ -9,14 +9,14 @@
     tag's memory.
 
     This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-    This library works with the Adafruit NFC breakout 
+    This library works with the Adafruit NFC breakout
       ----> https://www.adafruit.com/products/364
- 
-    Check out the links above for our tutorials and wiring diagrams 
+
+    Check out the links above for our tutorials and wiring diagrams
     These chips use SPI or I2C to communicate.
 
-    Adafruit invests time and resources providing this open source code, 
-    please support Adafruit and open-source hardware by purchasing 
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
     products from Adafruit!
 */
 /**************************************************************************/
@@ -50,11 +50,11 @@ Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
 // Or use this line for a breakout or shield with an I2C connection:
 //Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
-/*  
+/*
     We can encode many different kinds of pointers to the card,
     from a URL, to an Email address, to a phone number, and many more
     check the library header .h file to see the large # of supported
-    prefixes! 
+    prefixes!
 */
 // For a http://www. url:
 char * url = "adafruit.com/blog/";
@@ -82,15 +82,12 @@ void setup(void) {
     while (1); // halt
   }
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();  
 }
 
-void loop(void) 
+void loop(void)
 {
   uint8_t success;
   uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
@@ -108,9 +105,9 @@ void loop(void)
   // 1.) Wait for an NTAG203 card.  When one is found 'uid' will be populated with
   // the UID, and uidLength will indicate the size of the UID (normally 7)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
-  
+
   // It seems we found a valid ISO14443A Tag!
-  if (success) 
+  if (success)
   {
     // 2.) Display some basic information about the card
     Serial.println("Found an ISO14443A card");
@@ -118,7 +115,7 @@ void loop(void)
     Serial.print("  UID Value: ");
     nfc.PrintHex(uid, uidLength);
     Serial.println("");
-    
+
     if (uidLength != 7)
     {
       Serial.println("This doesn't seem to be an NTAG203 tag (UUID length != 7 bytes)!");
@@ -126,14 +123,14 @@ void loop(void)
     else
     {
       uint8_t data[32];
-      
+
       // We probably have an NTAG2xx card (though it could be Ultralight as well)
-      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");	  
-      
+      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");
+
       // NTAG2x3 cards have 39*4 bytes of user pages (156 user bytes),
       // starting at page 4 ... larger cards just add pages to the end of
       // this range:
-      
+
       // See: http://www.nxp.com/documents/short_data_sheet/NTAG203_SDS.pdf
 
       // TAG Type       PAGES   USER START    USER STOP
@@ -141,7 +138,7 @@ void loop(void)
       // NTAG 203       42      4             39
       // NTAG 213       45      4             39
       // NTAG 215       135     4             129
-      // NTAG 216       231     4             225      
+      // NTAG 216       231     4             225
 
 
       // 3.) Check if the NDEF Capability Container (CC) bits are already set
@@ -172,10 +169,10 @@ void loop(void)
           Serial.print("Tag is NDEF formatted. Data area size = ");
           Serial.print(dataLength);
           Serial.println(" bytes");
-          
+
           // 5.) Erase the old data area
           Serial.print("Erasing previous data area ");
-          for (uint8_t i = 4; i < (dataLength/4)+4; i++) 
+          for (uint8_t i = 4; i < (dataLength/4)+4; i++)
           {
             memset(data, 0, 4);
             success = nfc.ntag2xx_WritePage(i, data);
@@ -187,7 +184,7 @@ void loop(void)
             }
           }
           Serial.println(" DONE!");
-          
+
           // 6.) Try to add a new NDEF URI record
           Serial.print("Writing URI as NDEF Record ... ");
           success = nfc.ntag2xx_WriteNDEFURI(ndefprefix, url, dataLength);
@@ -199,17 +196,17 @@ void loop(void)
           {
             Serial.println("ERROR! (URI length?)");
           }
-                    
+
         } // CC contents NDEF record check
       } // CC page read check
     } // UUID length check
-    
+
     // Wait a bit before trying again
     Serial.flush();
     while (!Serial.available());
     while (Serial.available()) {
     Serial.read();
     }
-    Serial.flush();    
+    Serial.flush();
   } // Start waiting for a new ISO14443A tag
 }

--- a/examples/readMifareClassic/readMifareClassic.ino
+++ b/examples/readMifareClassic/readMifareClassic.ino
@@ -1,33 +1,33 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     readMifareClassic.pde
     @author   Adafruit Industries
 	@license  BSD (see license.txt)
 
     This example will wait for any ISO14443A card or tag, and
     depending on the size of the UID will attempt to read from it.
-   
+
     If the card has a 4-byte UID it is probably a Mifare
     Classic card, and the following steps are taken:
-   
+
     Reads the 4 byte (32 bit) ID of a MiFare Classic card.
     Since the classic cards have only 32 bit identifiers you can stick
 	them in a single variable and use that to compare card ID's as a
 	number. This doesn't work for ultralight cards that have longer 7
 	byte IDs!
-   
+
     Note that you need the baud rate to be 115200 because we need to
 	print out the data and read from the card at the same time!
 
 This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-This library works with the Adafruit NFC breakout 
+This library works with the Adafruit NFC breakout
   ----> https://www.adafruit.com/products/364
- 
-Check out the links above for our tutorials and wiring diagrams 
+
+Check out the links above for our tutorials and wiring diagrams
 These chips use SPI to communicate, 4 required to interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 */
 /**************************************************************************/
@@ -75,13 +75,10 @@ void setup(void) {
     while (1); // halt
   }
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
-  
+
   Serial.println("Waiting for an ISO14443A Card ...");
 }
 
@@ -90,29 +87,29 @@ void loop(void) {
   uint8_t success;
   uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
   uint8_t uidLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
-    
+
   // Wait for an ISO14443A type cards (Mifare, etc.).  When one is found
   // 'uid' will be populated with the UID, and uidLength will indicate
   // if the uid is 4 bytes (Mifare Classic) or 7 bytes (Mifare Ultralight)
   success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
-  
+
   if (success) {
     // Display some basic information about the card
     Serial.println("Found an ISO14443A card");
     Serial.print("  UID Length: ");Serial.print(uidLength, DEC);Serial.println(" bytes");
     Serial.print("  UID Value: ");
     nfc.PrintHex(uid, uidLength);
-    
+
     if (uidLength == 4)
     {
-      // We probably have a Mifare Classic card ... 
+      // We probably have a Mifare Classic card ...
       uint32_t cardid = uid[0];
       cardid <<= 8;
       cardid |= uid[1];
       cardid <<= 8;
-      cardid |= uid[2];  
+      cardid |= uid[2];
       cardid <<= 8;
-      cardid |= uid[3]; 
+      cardid |= uid[3];
       Serial.print("Seems to be a Mifare Classic card #");
       Serial.println(cardid);
     }

--- a/examples/readMifareClassicIrq/readMifareClassicIrq.ino
+++ b/examples/readMifareClassicIrq/readMifareClassicIrq.ino
@@ -1,31 +1,31 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     readMifareClassicIrq.pde
     @author   Adafruit Industries
 	@license  BSD (see license.txt)
 
     This example will wait for any ISO14443A card or tag, and
     depending on the size of the UID will attempt to read from it.
-   
+
     If the card has a 4-byte UID it is probably a Mifare
     Classic card, and the following steps are taken:
-   
+
     Reads the 4 byte (32 bit) ID of a MiFare Classic card.
     Since the classic cards have only 32 bit identifiers you can stick
 	them in a single variable and use that to compare card ID's as a
 	number. This doesn't work for ultralight cards that have longer 7
 	byte IDs!
-    
+
     Note that you need the baud rate to be 115200 because we need to
 	print out the data and read from the card at the same time!
 
 This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
-This library works with the Adafruit NFC breakout 
+This library works with the Adafruit NFC breakout
   ----> https://www.adafruit.com/products/364
- 
-Check out the links above for our tutorials and wiring diagrams 
 
-This example is for communicating with the PN532 chip using I2C. Wiring 
+Check out the links above for our tutorials and wiring diagrams
+
+This example is for communicating with the PN532 chip using I2C. Wiring
 should be as follows:
   PN532 SDA -> SDA pin
   PN532 SCL -> SCL pin
@@ -35,8 +35,8 @@ should be as follows:
   PN532 3.3v -> 3.3v
   PN532 GND -> GND
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 */
 /**************************************************************************/
@@ -78,12 +78,9 @@ void setup(void) {
     while (1); // halt
   }
   // Got ok data, print it out!
-  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
-  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX);
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC);
   Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
-  
-  // configure board to read RFID tags
-  nfc.SAMConfig();
 
   startListeningToNFC();
 }
@@ -99,10 +96,10 @@ void loop(void) {
 
     // When the IRQ is pulled low - the reader has got something for us.
     if (irqCurr == LOW && irqPrev == HIGH) {
-       Serial.println("Got NFC IRQ");  
-       handleCardDetected(); 
+       Serial.println("Got NFC IRQ");
+       handleCardDetected();
     }
-  
+
     irqPrev = irqCurr;
   }
 }
@@ -110,7 +107,7 @@ void loop(void) {
 void startListeningToNFC() {
   // Reset our IRQ indicators
   irqPrev = irqCurr = HIGH;
-  
+
   Serial.println("Waiting for an ISO14443A Card ...");
   nfc.startPassiveTargetIDDetection(PN532_MIFARE_ISO14443A);
 }
@@ -130,17 +127,17 @@ void handleCardDetected() {
       Serial.print("  UID Length: ");Serial.print(uidLength, DEC);Serial.println(" bytes");
       Serial.print("  UID Value: ");
       nfc.PrintHex(uid, uidLength);
-      
+
       if (uidLength == 4)
       {
-        // We probably have a Mifare Classic card ... 
+        // We probably have a Mifare Classic card ...
         uint32_t cardid = uid[0];
         cardid <<= 8;
         cardid |= uid[1];
         cardid <<= 8;
-        cardid |= uid[2];  
+        cardid |= uid[2];
         cardid <<= 8;
-        cardid |= uid[3]; 
+        cardid |= uid[3];
         Serial.print("Seems to be a Mifare Classic card #");
         Serial.println(cardid);
       }


### PR DESCRIPTION
For #45. Adds parameter to allow specifying alternate SPI bus. Only tested using default `SPI`, which still works.

Also some misc cleanup:
* Remove compatibility table from README. No longer valid.
* Remove call to `SAMConfig()` from **all** examples. This now gets called as part of the call to `begin()`.