### PR TITLE
Increase `PN532_PACKBUFFSIZ` to 128 bytes

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -75,7 +75,7 @@ byte pn532response_firmwarevers[] = {
 #define PN532DEBUGPRINT Serial ///< Fixed name for debug Serial instance
 //#define PN532DEBUGPRINT SerialUSB ///< Fixed name for debug Serial instance
 
-#define PN532_PACKBUFFSIZ 64                ///< Packet buffer size in bytes
+#define PN532_PACKBUFFSIZ 128               ///< Packet buffer size in bytes
 byte pn532_packetbuffer[PN532_PACKBUFFSIZ]; ///< Packet buffer used in various
                                             ///< transactions
 


### PR DESCRIPTION
This change is in response to a bug in this library found when working with NFC YubiKeys, which contain an NDEF record that is returned as 71 bytes (6 bytes of header, 63 bytes of payload, 2 bytes of status words).

It was found that when read using `inDataExchange()`, the last 15 bytes (13 bytes of payload and 2 bytes of status words) are being read as `00` rather than their actual value:

```
00 43 D1 01 3F 55 04 6D 79 2E 79 75 62 69 63 6F 2E 63 6F 6D 2F 79 6B 2F 23 76 76 63 63 63 62 69 63 75 6C 75 63 6A 6A 6E 67 6B 75 69 62 75 62 6E 74 6A 65 63 68 76 6A 66 00 00 00 00 00 00 00 00 00 00 00 00 00 // SW_1: 00; SW_2: 00
```

However the reading function still returns true as though it succeeded.

This has been documented [here](https://github.com/esphome/feature-requests/issues/2207#issuecomment-2332950416), and a suggested solution is to increase the size of `PN532_PACKBUFFSIZ`.

Although I'm not sure what the optimal size is, upping it to 128 solved my problem but is not wildly larger (given this is obviously meant for an embedded system).
