### PR TITLE
Added NTag2xx authentification (PWD_AUTH command), otherwise undoable

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1520,6 +1520,63 @@ uint8_t Adafruit_PN532::ntag2xx_WriteNDEFURI(uint8_t uriIdentifier, char *url,
   return 1;
 }
 
+/**************************************************************************/
+/*!
+ Tries to authenticate to a password protected NTAG2xx.
+
+ @param  password     The 4 byte password to try.
+ @param  acknowledge  The 2 bytes of PACK are written here if the
+                      authentification succeeded. This can be nullptr.
+
+ @returns 1 if everything executed properly, 0 for an error
+ */
+/**************************************************************************/
+uint8_t Adafruit_PN532::ntag2xx_Authenticate(const byte *password,
+                                             byte *acknowledge) {
+#if MIFAREDEBUG
+  PN532DEBUGPRINT.println(F("Trying to authenticate"));
+#endif
+
+  /* Prepare the command */
+  pn532_packetbuffer[0] = PN532_COMMAND_INCOMMUNICATETHRU;
+  pn532_packetbuffer[1] = 0x1B;                // PWD_AUTH command code
+  memcpy(pn532_packetbuffer + 2, password, 4); // 4 bytes or 32 bit password.
+
+#if MIFAREDEBUG
+  PN532DEBUGPRINT.print(F("Authenticate command: "));
+  Adafruit_PN532::PrintHexChar(pn532_packetbuffer, 6);
+#endif
+
+  /* Send the command */
+  if (!sendCommandCheckAck(pn532_packetbuffer, 2 + 4)) {
+#if MIFAREDEBUG
+    PN532DEBUGPRINT.println(F("Failed to receive ACK for authentification"));
+#endif
+    return 0;
+  }
+
+  /* Read the response packet */
+  readdata(pn532_packetbuffer, 8 + 4);
+#if MIFAREDEBUG
+  PN532DEBUGPRINT.print("Got authenticate response packet: ");
+  Adafruit_PN532::PrintHexChar(pn532_packetbuffer, 8 + 4);
+#endif
+  if (pn532_packetbuffer[7] == 0x00) {
+    // Positive response is 00 00 FF 05 FB D5 43 00 00 00 E8 00
+    if (acknowledge) { // Prevent nullpointer exception
+      acknowledge[0] = pn532_packetbuffer[8];
+      acknowledge[1] = pn532_packetbuffer[9];
+    }
+    return 1;
+  } else { // Byte 8 is 01
+#if MIFAREDEBUG
+    PN532DEBUGPRINT.println(F("Unexpected response for authentification"));
+#endif
+    // Is password is wrong we get 00 00 FF 03 FD D5 43 01 E7 00
+    return 0;
+  }
+}
+
 /************** high level communication functions (handles both I2C and SPI) */
 
 /**************************************************************************/

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -194,6 +194,7 @@ public:
   uint8_t ntag2xx_WritePage(uint8_t page, uint8_t *data);
   uint8_t ntag2xx_WriteNDEFURI(uint8_t uriIdentifier, char *url,
                                uint8_t dataLen);
+  uint8_t ntag2xx_Authenticate(const byte *password, byte *acknowledge);
 
   // Help functions to display formatted text
   static void PrintHex(const byte *data, const uint32_t numBytes);

--- a/examples/ntag2xx_authenticate/ntag2xx_authenticate.ino
+++ b/examples/ntag2xx_authenticate/ntag2xx_authenticate.ino
@@ -1,0 +1,147 @@
+/**************************************************************************/
+/*! 
+    @file     ntag2xx_authenticate.ino
+    @author   KTOWN (Adafruit Industries)
+    @license  BSD (see license.txt)
+    This example will wait for any NTAG203 or NTAG213 card or tag,
+    and will attempt to read from it.
+    This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
+    This library works with the Adafruit NFC breakout 
+      ----> https://www.adafruit.com/products/364
+ 
+    Check out the links above for our tutorials and wiring diagrams 
+    These chips use SPI or I2C to communicate.
+    Adafruit invests time and resources providing this open source code, 
+    please support Adafruit and open-source hardware by purchasing 
+    products from Adafruit!
+*/
+/**************************************************************************/
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_PN532.h>
+
+// If using the breakout with SPI, define the pins for SPI communication.
+#define PN532_SCK  (2)
+#define PN532_MOSI (3)
+#define PN532_SS   (4)
+#define PN532_MISO (5)
+
+// If using the breakout or shield with I2C, define just the pins connected
+// to the IRQ and reset lines.  Use the values below (2, 3) for the shield!
+#define PN532_IRQ   (2)
+#define PN532_RESET (3)  // Not connected by default on the NFC Shield
+
+// Uncomment just _one_ line below depending on how your breakout or shield
+// is connected to the Arduino:
+
+// Use this line for a breakout with a software SPI connection (recommended):
+//Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
+
+// Use this line for a breakout with a hardware SPI connection.  Note that
+// the PN532 SCK, MOSI, and MISO pins need to be connected to the Arduino's
+// hardware SPI SCK, MOSI, and MISO pins.  On an Arduino Uno these are
+// SCK = 13, MOSI = 11, MISO = 12.  The SS line can be any digital IO pin.
+//Adafruit_PN532 nfc(PN532_SS);
+
+// Or use this line for a breakout or shield with an I2C connection:
+Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
+
+void setup(void) {
+  Serial.begin(115200);
+  Serial.println("Hello!");
+
+  nfc.begin();
+
+  uint32_t versiondata = nfc.getFirmwareVersion();
+  if (! versiondata) {
+    Serial.print("Didn't find PN53x board");
+    while (1); // halt
+  }
+  // Got ok data, print it out!
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
+
+  // configure board to read RFID tags
+  nfc.SAMConfig();
+
+  Serial.println("Waiting for an ISO14443A Card ...");
+}
+
+void loop(void) {
+  uint8_t success;
+  uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
+  uint8_t uidLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
+
+  // Wait for an NTAG203 card.  When one is found 'uid' will be populated with
+  // the UID, and uidLength will indicate the size of the UUID (normally 7)
+  success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
+
+  if (success) {
+    // Display some basic information about the card
+    Serial.println("Found an ISO14443A card");
+    Serial.print("  UID Length: ");Serial.print(uidLength, DEC);Serial.println(" bytes");
+    Serial.print("  UID Value: ");
+    nfc.PrintHex(uid, uidLength);
+    Serial.println("");
+
+    if (uidLength == 7) {
+      uint8_t data[32];
+
+      // We probably have an NTAG2xx card (though it could be Ultralight as well)
+      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");    
+
+      // NTAG2x3 cards have 39*4 bytes of user pages (156 user bytes),
+      // starting at page 4 ... larger cards just add pages to the end of
+      // this range:
+
+      // See: http://www.nxp.com/documents/short_data_sheet/NTAG203_SDS.pdf
+
+      // TAG Type       PAGES   USER START    USER STOP
+      // --------       -----   ----------    ---------
+      // NTAG 203       42      4             39
+      // NTAG 213       45      4             39
+      // NTAG 215       135     4             129
+      // NTAG 216       231     4             225      
+
+      // Don't forget to replace with the password of  your chip
+      byte pwd[4] = {0x22, 0x66, 0x52, 0xC6};
+      nfc.ntag2xx_Authenticate(pwd, nullptr);
+      for (uint8_t i = 0; i < 42; i++) {
+        success = nfc.ntag2xx_ReadPage(i, data);
+
+        // Display the current page number
+        Serial.print("PAGE ");
+        if (i < 10) {
+          Serial.print("0");
+          Serial.print(i);
+        } else {
+          Serial.print(i);
+        }
+        Serial.print(": ");
+
+        // Display the results, depending on 'success'
+        if (success) {
+          // Dump the page data
+          nfc.PrintHexChar(data, 4);
+        } else {
+          Serial.println("Unable to read the requested page!");
+        }
+      }      
+
+    }
+    else
+    {
+      Serial.println("This doesn't seem to be an NTAG203 tag (UUID length != 7 bytes)!");
+    }
+
+    // Wait a bit before trying again
+    Serial.println("\n\nSend a character to scan another tag!");
+    Serial.flush();
+    while (!Serial.available());
+    while (Serial.available()) {
+    Serial.read();
+    }
+    Serial.flush();    
+  }
+}


### PR DESCRIPTION
* **Scope**: NTag2xx: added a minor functionnality but irreplaceable by user code: authentification (_PWD_AUTH_ command).
* **Testing**: Light testing on 3 different NTag215: works wonderfully.

This PR would add a member function of `Adafruit_PN532`, called `ntag2xx_Authenticate`, which allows the user to send a _PWD_AUTH_ command to the tag, in order authenticate with the password. Authenticating on NTag2xx allows writing on otherwise protected pages, and, according the the configuration of the tag, sometimes reading protected pages.
An example under `examples/ntag2xx_authenticate/ntag2xx_authenticate.ino` has been added. It is heavely inspired (if not copy-pasted) by @chrisgrill's work. 

This PR is similar to #59 and #19, which have not yet been implemented. This implementation is a bit different are more robust (in my opinion), in hopes of getting to the adafruit codebase and implement a well-requested feature.

The code has been formatted with `clang-format`, according the the README.